### PR TITLE
Fix extension error handling for OpenAI failures

### DIFF
--- a/__tests__/logger.test.js
+++ b/__tests__/logger.test.js
@@ -1,0 +1,15 @@
+import {jest} from '@jest/globals';
+import {logToGitHub} from '../src/logger.js';
+
+test('logToGitHub uploads log file', async () => {
+  const mockGet = jest.fn((defaults, cb) => cb({githubToken: 'tok', githubOwner: 'me', githubRepo: 'repo'}));
+  const mockStorage = {get: mockGet};
+  const mockFetch = jest.fn(() => Promise.resolve({status: 201}));
+  await logToGitHub('hello', {storage: mockStorage, fetchImpl: mockFetch});
+  expect(mockGet).toHaveBeenCalled();
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  const [url, opts] = mockFetch.mock.calls[0];
+  expect(url).toMatch(/https:\/\/api\.github\.com\/repos\/me\/repo\/contents\/logs\/log-\d+\.txt/);
+  expect(opts.method).toBe('PUT');
+  expect(opts.headers.Authorization).toBe('Bearer tok');
+});

--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,6 @@
 // background.js - version 2025-08-05T00:44:54Z
 import {strToBuf, b64ToBuf, fetchWithRetry} from './utils.js';
+import {logToGitHub} from './logger.js';
 
 let decryptedApiKey = null;
 
@@ -48,7 +49,7 @@ async function sendOpenAI(prompt, tabId) {
         'Authorization': `Bearer ${apiKey}`
       },
       body: JSON.stringify({
-        model: 'gpt-4.1-mini',
+        model: 'gpt-4o-mini',
         messages: [{role: 'user', content: prompt}],
         temperature: 0.7,
         max_tokens: 150,
@@ -91,7 +92,8 @@ async function sendOpenAI(prompt, tabId) {
       chrome.tabs.sendMessage(tabId, {type: 'done'});
     }
   } catch (err) {
-    chrome.tabs.sendMessage(tabId, {type: 'error'});
+    chrome.tabs.sendMessage(tabId, {type: 'error', data: err.message});
+    logToGitHub(`OpenAI request failed: ${err.message}\n${err.stack || ''}`).catch(() => {});
   }
 }
 

--- a/src/content.css
+++ b/src/content.css
@@ -33,7 +33,7 @@
     pointer-events: none;
 }
 
-.gptbtn.loading .btn-text {
+.gptbtn.loading .gptbtn-text {
     opacity: 0;
     pointer-events: none;
 }

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,28 @@
+import {bufToB64, strToBuf} from './utils.js';
+
+export async function logToGitHub(message, {storage = chrome?.storage?.local, fetchImpl = fetch} = {}) {
+  if (!storage) {
+    return;
+  }
+  const creds = await new Promise(resolve =>
+    storage.get({githubToken: '', githubOwner: '', githubRepo: ''}, resolve)
+  );
+  const {githubToken, githubOwner, githubRepo} = creds;
+  if (!githubToken || !githubOwner || !githubRepo) {
+    return;
+  }
+  const path = `logs/log-${Date.now()}.txt`;
+  const content = bufToB64(strToBuf(message));
+  await fetchImpl(`https://api.github.com/repos/${githubOwner}/${githubRepo}/contents/${path}`, {
+    method: 'PUT',
+    headers: {
+      'Authorization': `Bearer ${githubToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      message: `Add log ${path}`,
+      content
+    })
+  });
+  return path;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,8 @@
   ],
   "host_permissions": [
     "https://web.whatsapp.com/*",
-    "https://api.openai.com/*"
+    "https://api.openai.com/*",
+    "https://api.github.com/*"
   ],
   "content_scripts": [
     {

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -30,7 +30,6 @@ function saveOptions(e) {
     const sendHistory = document.querySelector('input[name="send-history"]:checked').value;
     const toneOfVoice = document.getElementById('tone-of-voice').value;
     const encryptKey = document.getElementById('encrypt-key').checked;
-    console.log('Saving options with sendHistory:', sendHistory);
 
     const storeObj = {
         sendHistory: sendHistory,
@@ -57,8 +56,7 @@ function saveOptions(e) {
             storeObj.iv = bufToB64(iv);
             storeObj.apiKey = '';
             chrome.storage.local.set(storeObj, () => {
-                console.log('Options saved successfully');
-                const alertBox = document.querySelector('.toast');
+                  const alertBox = document.querySelector('.toast');
                 alertBox.style.display = 'block';
                 setTimeout(function () {
                     alertBox.style.display = 'none';
@@ -73,8 +71,7 @@ function saveOptions(e) {
         storeObj.salt = '';
         storeObj.iv = '';
         chrome.storage.local.set(storeObj, () => {
-            console.log('Options saved successfully');
-            const alertBox = document.querySelector('.toast');
+              const alertBox = document.querySelector('.toast');
             alertBox.style.display = 'block';
             setTimeout(function () {
                 alertBox.style.display = 'none';

--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -1,51 +1,46 @@
 function createGptButton() {
-    const gptButton = document.createElement('button');
-    gptButton.innerHTML = '<span class="gptbtn-text">ChatGPT</span>\n' +
-        '  <span class="spinner"></span>\n'
-    gptButton.class = 'gptbtn';
+  const gptButton = document.createElement('button');
+  gptButton.innerHTML = '<span class="gptbtn-text">ChatGPT</span>\n' +
+    '  <span class="spinner"></span>\n';
+  gptButton.className = 'gptbtn';
+  gptButton.style.backgroundColor = '#D9FDD3';
+  gptButton.style.color = '#54656F';
+  gptButton.style.padding = '10px';
+  gptButton.style.border = 'none';
+  gptButton.style.borderRadius = '5px';
+  
+  // Add hover effect
+  gptButton.style.transition = 'background-color 0.3s ease';
+  gptButton.style.cursor = 'pointer';
 
-    gptButton.textContent = 'ChatGPT:';
+  gptButton.addEventListener('mouseover', () => {
+    gptButton.style.backgroundColor = '#BCE5A7';
+  });
+
+  gptButton.addEventListener('mouseout', () => {
     gptButton.style.backgroundColor = '#D9FDD3';
-    gptButton.style.color = '#54656F';
-    gptButton.style.padding = '10px';
-    gptButton.style.border = 'none';
-    gptButton.style.borderRadius = '5px';
+  });
 
+  // Add pressed effect
+  gptButton.style.boxShadow = 'inset 0 0 5px rgba(0, 0, 0, 0.2)';
 
-    // Add hover effect
-    gptButton.style.transition = 'background-color 0.3s ease';
-    gptButton.style.cursor = 'pointer';
+  gptButton.addEventListener('mousedown', () => {
+    gptButton.style.boxShadow = 'inset 0 0 10px rgba(0, 0, 0, 0.4)';
+  });
 
-    gptButton.addEventListener('mouseover', () => {
-        gptButton.style.backgroundColor = '#BCE5A7';
-    });
-
-    gptButton.addEventListener('mouseout', () => {
-        gptButton.style.backgroundColor = '#D9FDD3';
-    });
-
-    // Add pressed effect
+  gptButton.addEventListener('mouseup', () => {
     gptButton.style.boxShadow = 'inset 0 0 5px rgba(0, 0, 0, 0.2)';
-
-    gptButton.addEventListener('mousedown', () => {
-        gptButton.style.boxShadow = 'inset 0 0 10px rgba(0, 0, 0, 0.4)';
-    });
-
-    gptButton.addEventListener('mouseup', () => {
-        gptButton.style.boxShadow = 'inset 0 0 5px rgba(0, 0, 0, 0.2)';
-    });
-    return {
-        gptButton,
-        setBusy(value) {
-            if (value) {
-                gptButton.style.backgroundColor = '#D9FDD3';
-                gptButton.style.color = '#54656F';
-                gptButton.textContent = 'ChatGPT:';
-            } else {
-                gptButton.style.backgroundColor = '#D9FDD3';
-            }
-        }
-    };
+  });
+  return {
+    gptButton,
+    setBusy(value) {
+      if (value) {
+        gptButton.classList.add('loading');
+      } else {
+        gptButton.classList.remove('loading');
+      }
+    }
+  };
 }
 
 function createButton(pathVariable, title) {
@@ -61,8 +56,6 @@ function createButtonEmpty(title) {
     buttonElement.innerHTML = "<button class=\"svlsagor\"><span><svg viewBox=\"0 0 24 24\" height=\"24\" width=\"24\" preserveAspectRatio=\"xMidYMid meet\"></svg></span></button>";
     buttonElement.setAttribute('title', title)
     const svg = buttonElement.querySelector('svg')
-    // console.log('svgElement: ', svgElement);
-    console.log('buttonElement: ', buttonElement);
     return {svg, buttonElement};
 }
 
@@ -82,7 +75,6 @@ function creatCopyButton(newFooter, newButtonContainer) {
         svg: svgElement,
         buttonElement: copyButton
     } = createButtonEmpty('Copy chat suggestion');
-    // console.log('copyButton2: ', copyButton);
     svgElement.innerHTML = '<path d="M3,13c0-2.45,1.76-4.47,4.08-4.91L5.59,9.59L7,11l4-4.01L7,3L5.59,4.41l1.58,1.58l0,0.06C3.7,6.46,1,9.42,1,13 c0,3.87,3.13,7,7,7h3v-2H8C5.24,18,3,15.76,3,13z"/><path d="M13,13v7h9v-7H13z M20,18h-5v-3h5V18z"/><rect height="7" width="9" x="13" y="4"/>\n'
     newFooter.querySelectorAll('.selectable-text.copyable-text')[0];
     copyButton.style.marginRight = '10px';


### PR DESCRIPTION
## Summary
- default to `gpt-4o-mini` to avoid missing model errors
- forward OpenAI error messages to the UI for clearer feedback
- upload background errors as log files to a GitHub repo
- revert to a text-based ChatGPT button with spinner and drop oversized icon asset
- remove leftover debug logging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891762454488320b5119f6e70616e3f