### PR TITLE
Reset cached API key when storage changes

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -4,6 +4,12 @@ import {logToGitHub} from './logger.js';
 
 let decryptedApiKey = null;
 
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && (changes.encryptedApiKey || changes.apiKey)) {
+    decryptedApiKey = null;
+  }
+});
+
 async function getApiKey() {
   const {apiKey, encryptedApiKey, iv, encKey} = await chrome.storage.local.get({
     apiKey: '',


### PR DESCRIPTION
## Summary
- Clear cached decrypted key when `apiKey` or `encryptedApiKey` changes
- Ensure next call to `getApiKey` re-reads and decrypts latest value

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689205f7e76c832080e3b732d8d970bb