### PR TITLE
feat: add dark mode styles

### DIFF
--- a/src/content.css
+++ b/src/content.css
@@ -1,3 +1,24 @@
+/* Theme variables */
+:root {
+    --gpt-btn-bg: #007bff;
+    --gpt-btn-text: #fff;
+    --gpt-btn-spinner-border: rgba(255, 255, 255, 0.3);
+    --gpt-btn-spinner-top: #fff;
+    --message-spinner-border: rgba(0, 0, 0, 0.1);
+    --message-spinner-top: #54656F;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --gpt-btn-bg: #0056b3;
+        --gpt-btn-text: #fff;
+        --gpt-btn-spinner-border: rgba(255, 255, 255, 0.3);
+        --gpt-btn-spinner-top: #fff;
+        --message-spinner-border: rgba(255, 255, 255, 0.1);
+        --message-spinner-top: #d1d7db;
+    }
+}
+
 .gptbtn {
     position: relative;
     display: inline-block;
@@ -6,8 +27,8 @@
     font-weight: bold;
     text-align: center;
     text-decoration: none;
-    color: #fff;
-    background-color: #007bff;
+    color: var(--gpt-btn-text);
+    background-color: var(--gpt-btn-bg);
     border: none;
     border-radius: 4px;
     cursor: pointer;
@@ -24,8 +45,8 @@
     transform: translate(-50%, -50%);
     width: 20px;
     height: 20px;
-    border: 3px solid rgba(255, 255, 255, 0.3);
-    border-top-color: #fff;
+    border: 3px solid var(--gpt-btn-spinner-border);
+    border-top-color: var(--gpt-btn-spinner-top);
     border-radius: 50%;
     animation: spin 0.6s linear infinite;
     z-index: 0;
@@ -63,8 +84,8 @@
     display: block;
     width: 24px;
     height: 24px;
-    border: 3px solid rgba(0, 0, 0, 0.1);
-    border-top-color: #54656F;
+    border: 3px solid var(--message-spinner-border);
+    border-top-color: var(--message-spinner-top);
     border-radius: 50%;
     animation: spin 0.6s linear infinite;
     margin: 8px auto;

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -86,42 +86,49 @@ function extractConversation(node) {
 }
 
 function showPromptEditor() {
-    chrome.storage.local.get({toneOfVoice: 'Use Emoji and my own writing style. Be concise.'}, ({toneOfVoice}) => {
-        const overlay = document.createElement('div');
-        overlay.style.position = 'fixed';
-        overlay.style.top = '20%';
-        overlay.style.left = '50%';
-        overlay.style.transform = 'translateX(-50%)';
-        overlay.style.background = '#fff';
-        overlay.style.border = '1px solid #ccc';
-        overlay.style.padding = '10px';
-        overlay.style.zIndex = '10000';
-        const textarea = document.createElement('textarea');
-        textarea.rows = 4;
-        textarea.style.width = '200px';
-        textarea.value = toneOfVoice;
-        const saveBtn = document.createElement('button');
-        saveBtn.textContent = 'Save';
-        const resetBtn = document.createElement('button');
-        resetBtn.textContent = 'Reset to default';
-        const cancelBtn = document.createElement('button');
-        cancelBtn.textContent = 'Cancel';
-        saveBtn.addEventListener('click', () => {
-            chrome.storage.local.set({toneOfVoice: textarea.value});
-            document.body.removeChild(overlay);
-        });
-        resetBtn.addEventListener('click', () => {
-            textarea.value = 'Use Emoji and my own writing style. Be concise.';
-        });
-        cancelBtn.addEventListener('click', () => {
-            document.body.removeChild(overlay);
-        });
-        overlay.appendChild(textarea);
-        overlay.appendChild(saveBtn);
-        overlay.appendChild(resetBtn);
-        overlay.appendChild(cancelBtn);
-        document.body.appendChild(overlay);
+  chrome.storage.local.get({toneOfVoice: 'Use Emoji and my own writing style. Be concise.'}, ({toneOfVoice}) => {
+    const overlay = document.createElement('div');
+    overlay.style.position = 'fixed';
+    overlay.style.top = '20%';
+    overlay.style.left = '50%';
+    overlay.style.transform = 'translateX(-50%)';
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    overlay.style.background = prefersDark ? '#1e1e1e' : '#fff';
+    overlay.style.color = prefersDark ? '#fff' : '#000';
+    overlay.style.border = prefersDark ? '1px solid #444' : '1px solid #ccc';
+    overlay.style.padding = '10px';
+    overlay.style.zIndex = '10000';
+    const textarea = document.createElement('textarea');
+    textarea.rows = 4;
+    textarea.style.width = '200px';
+    if (prefersDark) {
+      textarea.style.background = '#2b2b2b';
+      textarea.style.color = '#fff';
+      textarea.style.border = '1px solid #444';
+    }
+    textarea.value = toneOfVoice;
+    const saveBtn = document.createElement('button');
+    saveBtn.textContent = 'Save';
+    const resetBtn = document.createElement('button');
+    resetBtn.textContent = 'Reset to default';
+    const cancelBtn = document.createElement('button');
+    cancelBtn.textContent = 'Cancel';
+    saveBtn.addEventListener('click', () => {
+      chrome.storage.local.set({toneOfVoice: textarea.value});
+      document.body.removeChild(overlay);
     });
+    resetBtn.addEventListener('click', () => {
+      textarea.value = 'Use Emoji and my own writing style. Be concise.';
+    });
+    cancelBtn.addEventListener('click', () => {
+      document.body.removeChild(overlay);
+    });
+    overlay.appendChild(textarea);
+    overlay.appendChild(saveBtn);
+    overlay.appendChild(resetBtn);
+    overlay.appendChild(cancelBtn);
+    document.body.appendChild(overlay);
+  });
 }
 
 let globalGptButtonObject;

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -148,4 +148,42 @@ button[type="submit"]:hover {
     text-align: center;
 }
 
+@media (prefers-color-scheme: dark) {
+    body {
+        color: #eee;
+        background-color: #121212;
+    }
+    form {
+        background-color: #1e1e1e;
+    }
+    input[type="password"],
+    .input-with-link input[type="text"] {
+        background-color: #2b2b2b;
+        color: #eee;
+        border: 1px solid #555;
+    }
+    fieldset {
+        border-color: #555;
+    }
+    button[type="submit"] {
+        background-color: #4a90e2;
+        color: #fff;
+    }
+    button[type="submit"]:hover {
+        background-color: #357ab8;
+    }
+    .custom-alert {
+        background-color: rgba(0, 0, 0, 0.7);
+    }
+    .custom-alert .alert-content {
+        background-color: #1e1e1e;
+        color: #eee;
+    }
+    .toast {
+        background-color: #1e1e1e;
+        border: 1px solid #555;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.8);
+    }
+}
+
 

--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -3,22 +3,28 @@ function createGptButton() {
   gptButton.innerHTML = '<span class="gptbtn-text">ChatGPT</span>\n' +
     '  <span class="spinner"></span>\n';
   gptButton.className = 'gptbtn';
-  gptButton.style.backgroundColor = '#D9FDD3';
-  gptButton.style.color = '#54656F';
+
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const baseBg = prefersDark ? '#005C4B' : '#D9FDD3';
+  const hoverBg = prefersDark ? '#1F7767' : '#BCE5A7';
+  const textColor = prefersDark ? '#E9EDEF' : '#54656F';
+
+  gptButton.style.backgroundColor = baseBg;
+  gptButton.style.color = textColor;
   gptButton.style.padding = '10px';
   gptButton.style.border = 'none';
   gptButton.style.borderRadius = '5px';
-  
+
   // Add hover effect
   gptButton.style.transition = 'background-color 0.3s ease';
   gptButton.style.cursor = 'pointer';
 
   gptButton.addEventListener('mouseover', () => {
-    gptButton.style.backgroundColor = '#BCE5A7';
+    gptButton.style.backgroundColor = hoverBg;
   });
 
   gptButton.addEventListener('mouseout', () => {
-    gptButton.style.backgroundColor = '#D9FDD3';
+    gptButton.style.backgroundColor = baseBg;
   });
 
   // Add pressed effect


### PR DESCRIPTION
## Summary
- make content styles theme-aware via CSS variables and dark mode overrides
- adapt GPT button colors to system theme
- add dark theme support for prompt editor and options page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689213a77168832090737adcc67bb3cb