### PR TITLE
Request API host permissions dynamically

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -140,6 +140,8 @@ function initExtension() {
     } else if (request.message === 'sendChatToGpt') {
       sendLLM(request.prompt, sender.tab.id);
       return true;
+    } else if (request.message === 'providerChanged' && request.providerUrl) {
+      chrome.permissions.request({origins: [request.providerUrl]});
     }
   });
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,9 @@
     "activeTab"
   ],
   "host_permissions": [
-    "https://web.whatsapp.com/*",
+    "https://web.whatsapp.com/*"
+  ],
+  "optional_host_permissions": [
     "https://api.openai.com/*",
     "https://openrouter.ai/*",
     "https://api.anthropic.com/*",


### PR DESCRIPTION
## Summary
- shift API domains to `optional_host_permissions`
- request host permissions when provider changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892dbdf1fec8320ace2a9fc94ab1e3b