### PR TITLE
Add reusable toast notifications

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,5 @@
 // background.js - version 2025-08-05T00:44:54Z
-import {b64ToBuf, fetchWithRetry} from './utils.js';
+import {b64ToBuf, fetchWithRetry, showToast} from './utils.js';
 import {logToGitHub} from './logger.js';
 
 let decryptedApiKey = null;
@@ -33,7 +33,9 @@ async function sendLLM(prompt, tabId) {
     const apiKey = await getApiKey();
     const {apiChoice, modelChoice} = await chrome.storage.local.get({apiChoice: 'openai', modelChoice: 'gpt-4o-mini'});
     if (!apiKey) {
-      chrome.tabs.sendMessage(tabId, {type: 'error', data: 'Please set your API key in the extension options.'});
+      const msg = 'Please set your API key in the extension options.';
+      chrome.tabs.sendMessage(tabId, {type: 'error', data: msg});
+      showToast(msg);
       return;
     }
 
@@ -129,6 +131,7 @@ async function sendLLM(prompt, tabId) {
     }
   } catch (err) {
     chrome.tabs.sendMessage(tabId, {type: 'error', data: err.message});
+    showToast(err.message);
     logToGitHub(`LLM request failed: ${err.message}\n${err.stack || ''}`).catch(() => {});
   }
 }

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1,6 +1,11 @@
 // contentScript.js - version 2025-08-05T00:44:54Z
 'use strict';
 
+let showToast;
+import(chrome.runtime.getURL('utils.js')).then(m => {
+  showToast = m.showToast;
+});
+
 // Content script file will run in the context of web page.
 // With content script you can manipulate the web pages using
 // Document Object Model (DOM).
@@ -39,26 +44,31 @@ chrome.storage.onChanged.addListener((changes, area) => {
 });
 
 function readData() {
-    try {
-        chrome.storage.local.get({
-            apiKey: '',
-            sendHistory: 'manual',
-        }, (result) => {
-            apiKey = result.apiKey;
-            sendHistory = result.sendHistory;
-        })
-    } catch (e) {
-        console.error('Error reading storage:', e);
-    }
+  try {
+    chrome.storage.local.get(
+      {
+        apiKey: '',
+        sendHistory: 'manual',
+      },
+      result => {
+        apiKey = result.apiKey;
+        sendHistory = result.sendHistory;
+      }
+    );
+  } catch (e) {
+    console.error('Error reading storage:', e);
+    if (showToast) showToast('Error reading storage');
+  }
 }
 
 async function copyToSendField(text) {
-    try {
-        const textareaEl = globalMainNode.querySelector('[contenteditable="true"]');
-        textareaEl.focus();
-        document.execCommand('insertText', false, text);
-    } catch (e) {
-    }
+  try {
+    const textareaEl = globalMainNode.querySelector('[contenteditable="true"]');
+    textareaEl.focus();
+    document.execCommand('insertText', false, text);
+  } catch (e) {
+    if (showToast) showToast('Failed to copy text');
+  }
 }
 
 let delayTimer;
@@ -328,28 +338,32 @@ async function writeTextToSuggestionField(response, isLoading = false) {
             newFooterParagraph.style.display = 'block';
             newFooterParagraph.innerHTML = response;
         }
-    } catch (e) {
-        console.error(e);
-    }
+  } catch (e) {
+    console.error(e);
+    if (showToast) showToast('Failed to update suggestion');
+  }
 }
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if (request.type === 'token') {
-        streamingText += request.data;
-        writeTextToSuggestionField(streamingText);
-    } else if (request.type === 'done') {
-        globalGptButtonObject.setBusy(false);
-    } else if (request.type === 'error') {
-        globalGptButtonObject.setBusy(false);
-        writeTextToSuggestionField(request.data || 'Failed to generate reply');
-    } else if (request.message === 'gptResponse') {
-        const response = request.response;
-        globalGptButtonObject.setBusy(false);
-        if (response.error !== null && response.error !== undefined) {
-            writeTextToSuggestionField(response.error.message);
-            return;
-        }
-        writeTextToSuggestionField(response.text.replace(/^Me:\s*/, ''));
+  if (request.type === 'token') {
+    streamingText += request.data;
+    writeTextToSuggestionField(streamingText);
+  } else if (request.type === 'done') {
+    globalGptButtonObject.setBusy(false);
+  } else if (request.type === 'error') {
+    globalGptButtonObject.setBusy(false);
+    writeTextToSuggestionField(request.data || 'Failed to generate reply');
+    if (showToast) showToast(request.data || 'Failed to generate reply');
+  } else if (request.type === 'showToast') {
+    if (showToast) showToast(request.message);
+  } else if (request.message === 'gptResponse') {
+    const response = request.response;
+    globalGptButtonObject.setBusy(false);
+    if (response.error !== null && response.error !== undefined) {
+      writeTextToSuggestionField(response.error.message);
+      return;
     }
-    return true;
+    writeTextToSuggestionField(response.text.replace(/^Me:\s*/, ''));
+  }
+  return true;
 });

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,87 +1,89 @@
 const encoder = new TextEncoder();
 
+let showToast;
+import(chrome.runtime.getURL('utils.js')).then(m => {
+  showToast = m.showToast;
+});
+
 class LinkedSet {
-    constructor() {
-        this.set = new Set();
-        this.array = [];
-    }
+  constructor() {
+    this.set = new Set();
+    this.array = [];
+  }
 
-    add(value) {
-        if (!this.set.has(value)) {
-            this.set.add(value);
-            this.array.push(value);
-        }
+  add(value) {
+    if (!this.set.has(value)) {
+      this.set.add(value);
+      this.array.push(value);
     }
+  }
 
-    getPosition(value) {
-        return this.array.indexOf(value);
-    }
+  getPosition(value) {
+    return this.array.indexOf(value);
+  }
 }
 
 function parseHtml(main) {
+  try {
     const main2 = main;
     const chatHistory = [];
-    // console.log(main2)
-    // Get both outgoing and incoming messages
-    let msgContainers = main2.querySelectorAll(".message-out, .message-in");
-    // let msgContainers = main2.querySelectorAll("div[data-testid='msg-container']");
+    let msgContainers = main2.querySelectorAll('.message-out, .message-in');
 
     const linkedSet = new LinkedSet();
     msgContainers = Array.from(msgContainers).slice(-10);
-    msgContainers.forEach((el) => {
-        let messageStringCollector = '';
-        const elements = el.querySelectorAll('.copyable-text');
-        elements.forEach((el) => {
-            const messageLabel = el.getAttribute('data-pre-plain-text');
-            if (messageLabel !== null) { // get the prefix (person)
-                if (el.closest('.message-out') !== null) {
-                    messageStringCollector += "Me: ";
-                } else {
-                    // contactName should be obfuscated into a number, but repetitive utterances by the same user should carry the same label:
-                    let contactName = messageLabel.replace(/\[.*?\]\s*/, "").slice(0, -2)
-                    linkedSet.add(contactName)
-                    const contactNumber = linkedSet.getPosition(contactName) + 1
-                    // Using only the number turned out to be the only way to coerce GPT to no refer to these substitute label's It's a pity we cannot use the real names, but that would make it too privacy-sensitive, especially since you expose what other people said too.
-                    messageStringCollector += contactNumber + ": ";
-                }
-            } else { // get the message itself
-                const messageContent = getTextWithEmojis(el);
-                if (typeof messageContent !== "undefined") {
-                    messageStringCollector += messageContent;
-                }
-            }
-        })
-        if (messageStringCollector.length !== 0) {
-            chatHistory.push(messageStringCollector);
+    msgContainers.forEach(el => {
+      let messageStringCollector = '';
+      const elements = el.querySelectorAll('.copyable-text');
+      elements.forEach(el => {
+        const messageLabel = el.getAttribute('data-pre-plain-text');
+        if (messageLabel !== null) {
+          if (el.closest('.message-out') !== null) {
+            messageStringCollector += 'Me: ';
+          } else {
+            let contactName = messageLabel.replace(/\[.*?\]\s*/, '').slice(0, -2);
+            linkedSet.add(contactName);
+            const contactNumber = linkedSet.getPosition(contactName) + 1;
+            messageStringCollector += contactNumber + ': ';
+          }
+        } else {
+          const messageContent = getTextWithEmojis(el);
+          if (typeof messageContent !== 'undefined') {
+            messageStringCollector += messageContent;
+          }
         }
+      });
+      if (messageStringCollector.length !== 0) {
+        chatHistory.push(messageStringCollector);
+      }
     });
-    // console.log('count', chatHistory.length)
-    // if last expression is mine
     const lastExpression = chatHistory[chatHistory.length - 1];
     let lastIsMine = false;
-    if (lastExpression.includes("Me:")) {
-        lastIsMine = true
+    if (lastExpression.includes('Me:')) {
+      lastIsMine = true;
     }
-    const chatHistoryShortAsString = chatHistory.join('\n\n')
-    // console.log(chatHistoryShortAsString);
-    return {chatHistoryShort: chatHistoryShortAsString, lastIsMine: lastIsMine}
+    const chatHistoryShortAsString = chatHistory.join('\n\n');
+    return {chatHistoryShort: chatHistoryShortAsString, lastIsMine};
+  } catch (e) {
+    console.error('Failed to parse chat history:', e);
+    if (showToast) showToast('Failed to parse chat history');
+    return {chatHistoryShort: '', lastIsMine: false};
+  }
 }
 
 function getTextWithEmojis(element) {
-    let result = '';
+  let result = '';
 
-    for (const childNode of element.childNodes) {
-        if (childNode.nodeType === Node.TEXT_NODE) {
-            result += childNode.textContent;
-        } else if (childNode.nodeType === Node.ELEMENT_NODE) {
-            if (childNode.tagName === 'IMG' && childNode.hasAttribute('data-plain-text')) {
-                result += childNode.getAttribute('data-plain-text');
-            } else {
-                result += getTextWithEmojis(childNode);
-            }
-        }
+  for (const childNode of element.childNodes) {
+    if (childNode.nodeType === Node.TEXT_NODE) {
+      result += childNode.textContent;
+    } else if (childNode.nodeType === Node.ELEMENT_NODE) {
+      if (childNode.tagName === 'IMG' && childNode.hasAttribute('data-plain-text')) {
+        result += childNode.getAttribute('data-plain-text');
+      } else {
+        result += getTextWithEmojis(childNode);
+      }
     }
+  }
 
-    return result;
+  return result;
 }
-

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,3 +47,39 @@ export async function fetchWithRetry(
     }
   }
 }
+
+export function showToast(message) {
+  if (typeof window !== 'undefined' && window.document && document.body) {
+    const toast = document.createElement('div');
+    toast.textContent = message;
+    toast.style.position = 'fixed';
+    toast.style.bottom = '20px';
+    toast.style.left = '50%';
+    toast.style.transform = 'translateX(-50%)';
+    toast.style.background = 'rgba(0, 0, 0, 0.8)';
+    toast.style.color = '#fff';
+    toast.style.padding = '8px 12px';
+    toast.style.borderRadius = '4px';
+    toast.style.zIndex = '2147483647';
+    document.body.appendChild(toast);
+    setTimeout(() => toast.remove(), 3000);
+  } else if (typeof chrome !== 'undefined' && chrome.tabs && chrome.tabs.query) {
+    try {
+      chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+        if (tabs[0] && tabs[0].id !== undefined) {
+          chrome.tabs.sendMessage(tabs[0].id, {type: 'showToast', message});
+        }
+      });
+    } catch (e) {
+      // ignore messaging errors
+    }
+  } else if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.sendMessage) {
+    try {
+      chrome.runtime.sendMessage({type: 'showToast', message});
+    } catch (e) {
+      // ignore runtime errors
+    }
+  } else {
+    console.log(message);
+  }
+}


### PR DESCRIPTION
## Summary
- add `showToast` helper to display visual error notifications across contexts
- use toast helper for API and storage errors in background, content, and parser scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892dbe9870c83209a59e1eca451d5b5