### PR TITLE
Wrap options form and history in flex layout

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -25,12 +25,23 @@ h1 {
 }
 
 /* Form styling */
+
+.options-container {
+    display: flex;
+    gap: 20px;
+}
+
 form {
     background-color: #fff;
     border-radius: 5px;
     padding: 20px;
+    flex: 1;
     max-width: 500px;
-    margin: 0 auto;
+    margin: 0;
+}
+
+#history {
+    flex: 1;
 }
 
 label {
@@ -183,6 +194,12 @@ button[type="submit"]:hover {
         background-color: #1e1e1e;
         border: 1px solid #555;
         box-shadow: 0 0 10px rgba(0, 0, 0, 0.8);
+    }
+}
+
+@media (max-width: 600px) {
+    .options-container {
+        flex-direction: column;
     }
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -8,24 +8,7 @@
 </head>
 <body>
 <h1>Options for GPT answer-suggestions</h1>
-<div id="chatHistoryWarningAlert" class="custom-alert">
-    <div class="alert-content">
-        <div>
-            <p>The last messages of your chat-conversation will be sent to the selected AI provider automatically, each time you
-                select another user, <br> or when a message comes into the currently
-                selected conversation.<br>
-                They are kept and used according to that provider's API documentation and privacy policy.<br> This is
-                less secure than the end-to-end encryption that <a
-                        href="https://faq.whatsapp.com/820124435853543/?helpref=uf_share"
-                        target="_blank">whatsapp(tm) uses</a>.<br></p>
-        </div>
-        <div style="text-align: center;">
-            <p><strong><span style="color: red;">Beware to leave this off in sensitive conversations!</span></strong>
-            </p>
-            <button type="submit" id="hideHistoryWarningAlert">I understand</button>
-        </div>
-    </div>
-</div>
+<div class="options-container">
 <form id="options-form">
     <fieldset>
         <legend>Trigger chat answers from GPT:</legend>
@@ -80,6 +63,26 @@
         <p>Options saved successfully!</p>
     </div>
 </form>
+<div id="history"></div>
+</div>
+<div id="chatHistoryWarningAlert" class="custom-alert">
+    <div class="alert-content">
+        <div>
+            <p>The last messages of your chat-conversation will be sent to the selected AI provider automatically, each time you
+                select another user, <br> or when a message comes into the currently
+                selected conversation.<br>
+                They are kept and used according to that provider's API documentation and privacy policy.<br> This is
+                less secure than the end-to-end encryption that <a
+                        href="https://faq.whatsapp.com/820124435853543/?helpref=uf_share"
+                        target="_blank">whatsapp(tm) uses</a>.<br></p>
+        </div>
+        <div style="text-align: center;">
+            <p><strong><span style="color: red;">Beware to leave this off in sensitive conversations!</span></strong>
+            </p>
+            <button type="submit" id="hideHistoryWarningAlert">I understand</button>
+        </div>
+    </div>
+</div>
 <script type="module" src="options.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- group options form with new history section in a flex container
- style options page with side-by-side layout and responsive stacking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892dbef6d048320a7fe13acf3ff6f72