### PR TITLE
feat: show options page as popup

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -78,21 +78,23 @@ let newFooterParagraph;
 async function createPrompt(lastIsMine, chatHistoryShort) {
     let promptCenter;
     let mePrefix = 'Me: ';
-    let promptPrefix1 = "You are an excellent chat-turn completer for Whatsapp. Your own turns in the provided chat-history are prefixed by 'Me: ', the turns of others by '<integer>: '. In a one-on-one coversation the other's turn is prefixed by '1: '.";
     if (lastIsMine) {
         promptCenter = 'Complete the following chat by providing a second message for my double-texting sequence. Do not react but continue the thought, elaborate, or add a supplementary point, without repeating the last utterance.';
     } else {
         promptCenter = 'As "Me", give an utterance completing the following chat conversation flow.';
     }
 
+    const {DEFAULT_PROMPT} = await import(chrome.runtime.getURL('utils.js'));
     const result = await new Promise((resolve) => {
         chrome.storage.local.get({
-            toneOfVoice: 'Use Emoji and my own writing style. Be concise.'
+            toneOfVoice: 'Use Emoji and my own writing style. Be concise.',
+            promptTemplate: DEFAULT_PROMPT
         }, resolve);
     });
 
     const tone_of_voice = result.toneOfVoice;
-    let prompt = promptPrefix1 + ' ' + promptCenter + ' ' + tone_of_voice + '\n\n' + "chat history:\n" + chatHistoryShort + "\n\n" + mePrefix;
+    const promptTemplate = result.promptTemplate;
+    const prompt = `${promptTemplate}\n${promptCenter}\nTone of voice: ${tone_of_voice}\n\nchat history:\n${chatHistoryShort}\n\n${mePrefix}`;
     return prompt;
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,8 @@
   },
   "action": {
     "default_title": "AI Suggested Replies For WhatsApp",
-    "default_icon": "icons/Ext-Icon-1.png"
+    "default_icon": "icons/Ext-Icon-1.png",
+    "default_popup": "options/options.html"
   },
   "options_page": "options/options.html",
   "permissions": [

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -67,6 +67,14 @@
     </fieldset>
 
     <fieldset>
+        <legend>Prompt:</legend>
+        <div>
+            <label for="prompt-template">Base prompt used to generate replies:</label>
+            <textarea id="prompt-template" name="prompt-template" rows="12" style="width: 100%;"></textarea>
+        </div>
+    </fieldset>
+
+    <fieldset>
         <legend>Tone of Voice:</legend>
         <div>
             <label for="tone-of-voice">This is only the tone of voice you want to use, it will be inserted into the

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,4 +1,4 @@
-import {strToBuf, bufToB64, b64ToBuf} from '../utils.js';
+import {strToBuf, bufToB64, b64ToBuf, DEFAULT_PROMPT} from '../utils.js';
 
 document.addEventListener('DOMContentLoaded', restoreOptions);
 document.getElementById('options-form').addEventListener('submit', saveOptions);
@@ -99,6 +99,7 @@ async function saveOptions(e) {
   const apiKey = document.getElementById('api-key').value;
   const sendHistory = document.querySelector('input[name="send-history"]:checked').value;
   const toneOfVoice = document.getElementById('tone-of-voice').value;
+  const promptTemplate = document.getElementById('prompt-template').value;
   const apiChoice = apiChoiceSelect.value;
   const modelChoice = modelChoiceSelect.value;
 
@@ -111,6 +112,7 @@ async function saveOptions(e) {
     apiChoice: apiChoice,
     modelChoice: modelChoice,
     toneOfVoice: toneOfVoice,
+    promptTemplate: promptTemplate,
     encryptedApiKey: bufToB64(encrypted),
     iv: bufToB64(iv),
     apiKey: ''
@@ -135,7 +137,8 @@ async function restoreOptions() {
     sendHistory: 'manual',
     apiChoice: 'openai',
     modelChoice: 'gpt-4o-mini',
-    toneOfVoice: 'Use Emoji and my own writing style. Be concise.'
+    toneOfVoice: 'Use Emoji and my own writing style. Be concise.',
+    promptTemplate: DEFAULT_PROMPT
   });
   if (items.encryptedApiKey && items.iv && items.encKey) {
     try {
@@ -149,6 +152,7 @@ async function restoreOptions() {
     apiKeyInput.value = items.apiKey;
   }
   document.getElementById('tone-of-voice').value = items.toneOfVoice;
+  document.getElementById('prompt-template').value = items.promptTemplate;
   apiChoiceSelect.value = items.apiChoice;
   modelChoiceSelect.value = items.modelChoice;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,19 @@
 // Utility functions for encryption and retries
 // Shared between background and options scripts
+
+export const DEFAULT_PROMPT = `You are an AI-powered reply assistant integrated into a Chrome extension for WhatsApp Web.
+You will receive the last 10 user and contact messages in a conversation.
+Your job is to generate one or more short, contextually accurate, and natural-sounding reply suggestions.
+Follow these rules:
+- Maintain the conversation flow and tone from the recent messages.
+- Be concise (1–2 sentences per reply).
+- Avoid repeating exact phrases from earlier messages unless necessary for politeness or clarity.
+- Do not ask redundant questions already answered in the conversation.
+- Maintain grammatical correctness and natural language style.
+- Keep replies friendly and human-like without sounding overly formal unless the conversation tone requires it.
+- Do not add extra explanation, metadata, or reasoning—only output the suggested reply text(s).
+- If instructed in the tone-of-voice setting, adapt word choice, formality, and style accordingly.`;
+
 export function strToBuf(str) {
   return new TextEncoder().encode(str);
 }


### PR DESCRIPTION
## Summary
- open extension options page when the action icon is clicked by adding `default_popup` to the manifest's action section
- allow configuring a default prompt in the settings page and use it when generating replies

## Testing
- `npm test`
- `node --input-type=module -e "import {DEFAULT_PROMPT} from './src/utils.js'; console.log(DEFAULT_PROMPT.split('\\n')[0]);"`
- `node --input-type=module -e "import fs from 'fs'; const html=fs.readFileSync('src/options/options.html','utf8'); console.log(html.includes('prompt-template') ? 'prompt field exists' : 'missing');"`


------
https://chatgpt.com/codex/tasks/task_e_6892dbd052988320ad4da1498237339c