### PR TITLE
Restore options UI and consolidate shared utils

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1,10 +1,11 @@
-// contentScript.js - version 2025-08-05T00:44:54Z
-'use strict';
+(() => {
+  // contentScript.js - version 2025-08-05T00:44:54Z
+  'use strict';
 
-let showToast;
-import(chrome.runtime.getURL('utils.js')).then(m => {
-  showToast = m.showToast;
-});
+  let showToast;
+  import(chrome.runtime.getURL('utils.js')).then(m => {
+    showToast = m.showToast;
+  });
 
 // Content script file will run in the context of web page.
 // With content script you can manipulate the web pages using
@@ -461,3 +462,5 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
   return true;
 });
+
+})();

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -55,6 +55,14 @@
     </fieldset>
 
     <fieldset>
+        <legend>API Key:</legend>
+        <label for="api-key">API Key:</label>
+        <input type="password" id="api-key" name="api-key">
+        <button type="button" id="toggle-api-key">Show</button>
+        <span id="api-key-status"></span>
+    </fieldset>
+
+    <fieldset>
         <legend>Prompt:</legend>
         <div>
             <label for="prompt-template">Base prompt used to generate replies:</label>

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,11 +1,10 @@
-const encoder = new TextEncoder();
+(() => {
+  let showToast;
+  import(chrome.runtime.getURL('utils.js')).then(m => {
+    showToast = m.showToast;
+  });
 
-let showToast;
-import(chrome.runtime.getURL('utils.js')).then(m => {
-  showToast = m.showToast;
-});
-
-class LinkedSet {
+  class LinkedSet {
   constructor() {
     this.set = new Set();
     this.array = [];
@@ -68,9 +67,9 @@ function parseHtml(main) {
     if (showToast) showToast('Failed to parse chat history');
     return {chatHistoryShort: '', lastIsMine: false};
   }
-}
+  }
 
-function getTextWithEmojis(element) {
+  function getTextWithEmojis(element) {
   let result = '';
 
   for (const childNode of element.childNodes) {
@@ -86,4 +85,7 @@ function getTextWithEmojis(element) {
   }
 
   return result;
-}
+  }
+
+  window.parseHtml = parseHtml;
+})();

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,8 @@
 // Utility functions for encryption and retries
 // Shared between background and options scripts
 
+export const encoder = new TextEncoder();
+
 export const DEFAULT_PROMPT = `You are an AI-powered reply assistant integrated into a Chrome extension for WhatsApp Web.
 You will receive the last 10 user and contact messages in a conversation.
 Your job is to generate one or more short, contextually accurate, and natural-sounding reply suggestions.


### PR DESCRIPTION
## Summary
- reinstate options page UI and add API key fieldset
- centralize shared helpers by exporting encoder from utils
- wrap parser and content scripts in IIFEs to avoid duplicate globals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892fec5db0083208d2bc26b0e055dd8