### PR TITLE
Fix confirm dialog visibility and expose utils module

### DIFF
--- a/src/confirmDialog.js
+++ b/src/confirmDialog.js
@@ -1,77 +1,72 @@
+let confirmVisible = false;
+
 function confirmDialog(message) {
-    if (confirmVisible) {
-        return new Promise((resolve) => {
-            resolve(false)
-        });
-    }
-    return new Promise((resolve) => {
-        confirmVisible = true;
-        // Create the dialog box element
-        let confirmDialog = document.createElement("div");
-        confirmDialog.id = "confirmDialog";
-        confirmDialog.innerHTML = "<style>" +
-            "#confirmDialog ul li {" +
-            "  list-style-type: disc;" +
-            "  margin-bottom: 10px;" +
-            "  font-size: 14px;" +
-            "  line-height: 1.5;" +
-            "}" +
-            "</style>" +
-            message +
-            "<div id='buttonsContainer'>" +
-            "<button id='confirmYes'>Yes</button>" +
-            "<button id='confirmNo'>No</button>" +
-            "</div>";
-        document.body.appendChild(confirmDialog);
+  if (confirmVisible) {
+    return Promise.resolve(false);
+  }
+  return new Promise((resolve) => {
+    confirmVisible = true;
+    let confirmDialog = document.createElement("div");
+    confirmDialog.id = "confirmDialog";
+    confirmDialog.innerHTML = "<style>" +
+      "#confirmDialog ul li {" +
+      "  list-style-type: disc;" +
+      "  margin-bottom: 10px;" +
+      "  font-size: 14px;" +
+      "  line-height: 1.5;" +
+      "}" +
+      "</style>" +
+      message +
+      "<div id='buttonsContainer'>" +
+      "<button id='confirmYes'>Yes</button>" +
+      "<button id='confirmNo'>No</button>" +
+      "</div>";
+    document.body.appendChild(confirmDialog);
 
-        // Get the yes and no buttons
-        let confirmYes = document.getElementById("confirmYes");
-        let confirmNo = document.getElementById("confirmNo");
+    let confirmYes = document.getElementById("confirmYes");
+    let confirmNo = document.getElementById("confirmNo");
 
-        // Add event listeners to the buttons
-        confirmYes.addEventListener("click", function () {
-            document.body.removeChild(confirmDialog);
-            confirmVisible = false
-            resolve(true);
-        });
-
-        confirmNo.addEventListener("click", function () {
-            document.body.removeChild(confirmDialog);
-            confirmVisible = false
-            resolve(false);
-        });
-
-        // Show the confirm dialog
-        confirmDialog.style.display = "block";
-
-        // Add CSS styles to the dialog box
-        confirmDialog.style.position = "fixed";
-        confirmDialog.style.bottom = "80px";
-        confirmDialog.style.left = "55%";
-        confirmDialog.style.transform = "translate(-50%, -50%)";
-        confirmDialog.style.backgroundColor = "#fff";
-        confirmDialog.style.borderRadius = "10px";
-        confirmDialog.style.boxShadow = "0 0 10px rgba(0, 0, 0, 0.3)";
-        confirmDialog.style.padding = "20px";
-        confirmDialog.style.textAlign = "start";
-        confirmDialog.style.zIndex = "9999";
-        confirmDialog.style.paddingLeft = "40px";
-
-        let buttonStyle = "background-color: #0077ff; " +
-            "color: #fff; " +
-            "border: none; " +
-            "padding: 10px 20px; " +
-            "border-radius: 5px; " +
-            "cursor: pointer; " +
-            "margin: 10px;";
-
-        confirmYes.style.cssText = buttonStyle;
-        confirmNo.style.cssText = buttonStyle;
-
-        // Add CSS styles to the buttons container
-        let buttonsContainer = document.getElementById("buttonsContainer");
-        buttonsContainer.style.display = "flex";
-        buttonsContainer.style.justifyContent = "center";
-        buttonsContainer.style.marginTop = "10px";
+    confirmYes.addEventListener("click", function () {
+      document.body.removeChild(confirmDialog);
+      confirmVisible = false;
+      resolve(true);
     });
+
+    confirmNo.addEventListener("click", function () {
+      document.body.removeChild(confirmDialog);
+      confirmVisible = false;
+      resolve(false);
+    });
+
+    confirmDialog.style.display = "block";
+
+    confirmDialog.style.position = "fixed";
+    confirmDialog.style.bottom = "80px";
+    confirmDialog.style.left = "55%";
+    confirmDialog.style.transform = "translate(-50%, -50%)";
+    confirmDialog.style.backgroundColor = "#fff";
+    confirmDialog.style.borderRadius = "10px";
+    confirmDialog.style.boxShadow = "0 0 10px rgba(0, 0, 0, 0.3)";
+    confirmDialog.style.padding = "20px";
+    confirmDialog.style.textAlign = "start";
+    confirmDialog.style.zIndex = "9999";
+    confirmDialog.style.paddingLeft = "40px";
+
+    let buttonStyle = "background-color: #0077ff; " +
+      "color: #fff; " +
+      "border: none; " +
+      "padding: 10px 20px; " +
+      "border-radius: 5px; " +
+      "cursor: pointer; " +
+      "margin: 10px;";
+
+    confirmYes.style.cssText = buttonStyle;
+    confirmNo.style.cssText = buttonStyle;
+
+    let buttonsContainer = document.getElementById("buttonsContainer");
+    buttonsContainer.style.display = "flex";
+    buttonsContainer.style.justifyContent = "center";
+    buttonsContainer.style.marginTop = "10px";
+  });
 }
+

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -399,7 +399,6 @@ const observer = new MutationObserver(mutations => {
   });
 });
 
-let confirmVisible = false;
 
 function initExtension() {
   readData();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -33,5 +33,11 @@
     "https://api.anthropic.com/*",
     "https://api.mistral.ai/*",
     "https://api.github.com/*"
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["utils.js"],
+      "matches": ["https://web.whatsapp.com/*"]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- expose `utils.js` as a web accessible resource so content scripts can dynamically import it
- add `confirmVisible` state and clean up confirm dialog logic to avoid ReferenceError
- remove unused `confirmVisible` reference from content script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68931c5c0d3483209d85746bbd6699c4