### PR TITLE
Fix multiline rendering and remove prompt editor

### DIFF
--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -1,8 +1,7 @@
 function createGptButton() {
   const gptButton = document.createElement('button');
   gptButton.type = 'button';
-  gptButton.innerHTML = '<span class="gptbtn-text">AI Reply</span>\n' +
-    '  <span class="spinner"></span>\n';
+  gptButton.innerHTML = '<span class="gptbtn-text">AI Reply</span><span class="spinner"></span>';
   gptButton.className = 'gptbtn';
 
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;


### PR DESCRIPTION
## Summary
- render AI responses in a single block with preserved line breaks
- remove unused "Edit Prompt" UI and related code
- ensure the AI Reply button always stays on one line

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689321a2a4e8832081f5b4cb2a11a604