### PR TITLE
Adapt copy icon to theme and center loader

### DIFF
--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -44,9 +44,12 @@ function createGptButton(label = 'Suggest Response', id) {
     gptButton,
     setBusy(value) {
       if (value) {
+        const width = gptButton.getBoundingClientRect().width;
+        gptButton.style.width = `${width}px`;
         gptButton.classList.add('loading');
       } else {
         gptButton.classList.remove('loading');
+        gptButton.style.width = '';
       }
     }
   };
@@ -80,15 +83,25 @@ function createAndAddOptionsButton(newButtonContainer) {
 }
 
 function creatCopyButton(newFooter, newButtonContainer) {
-    const {
-        svg: svgElement,
-        buttonElement: copyButton
-    } = createButtonEmpty('Copy chat suggestion');
-    svgElement.innerHTML = '<path d="M3,13c0-2.45,1.76-4.47,4.08-4.91L5.59,9.59L7,11l4-4.01L7,3L5.59,4.41l1.58,1.58l0,0.06C3.7,6.46,1,9.42,1,13 c0,3.87,3.13,7,7,7h3v-2H8C5.24,18,3,15.76,3,13z"/><path d="M13,13v7h9v-7H13z M20,18h-5v-3h5V18z"/><rect height="7" width="9" x="13" y="4"/>\n'
-    newFooter.querySelectorAll('.selectable-text.copyable-text')[0];
-    copyButton.style.marginRight = '10px';
-    newButtonContainer.appendChild(copyButton);
-    return copyButton;
+  const {
+    svg: svgElement,
+    buttonElement: copyButton
+  } = createButtonEmpty('Copy chat suggestion');
+  svgElement.innerHTML = '<path d="M3,13c0-2.45,1.76-4.47,4.08-4.91L5.59,9.59L7,11l4-4.01L7,3L5.59,4.41l1.58,1.58l0,0.06C3.7,6.46,1,9.42,1,13 c0,3.87,3.13,7,7,7h3v-2H8C5.24,18,3,15.76,3,13z"/><path d="M13,13v7h9v-7H13z M20,18h-5v-3h5V18z"/><rect height="7" width="9" x="13" y="4"/>\n';
+  svgElement.setAttribute('fill', 'currentColor');
+  const theme = window.matchMedia('(prefers-color-scheme: dark)');
+  const innerBtn = copyButton.querySelector('button');
+  function applyIconColor() {
+    const color = theme.matches ? '#E9EDEF' : '#54656F';
+    copyButton.style.color = color;
+    if (innerBtn) innerBtn.style.color = color;
+  }
+  applyIconColor();
+  theme.addEventListener('change', applyIconColor);
+  newFooter.querySelectorAll('.selectable-text.copyable-text')[0];
+  copyButton.style.marginRight = '10px';
+  newButtonContainer.appendChild(copyButton);
+  return copyButton;
 }
 
 function createGptFooter(footer, mainNode) {


### PR DESCRIPTION
## Summary
- Make copy-chat-suggestion icon adapt to dark and light modes using `currentColor` and media query
- Ensure GPT buttons keep fixed width so the loader appears centered

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68938b7c387c8320a3f1feb8c786f6a4