### PR TITLE
Revamp options page and streamline settings

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,186 +1,143 @@
-/* options.css */
-
-/* General styling */
-* {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+:root {
+  --whats-green: #25d366;
+  --light-bg: #fff;
+  --light-text: #111b21;
+  --light-border: #ddd;
+  --dark-bg: #111b21;
+  --dark-text: #e9edef;
+  --dark-border: #23272b;
 }
+
 body {
-    font-family: Arial, sans-serif;
-    line-height: 1.6;
-    color: #333;
-    background-color: #f4f4f4;
-    padding: 20px;
-}
-
-h1 {
-    font-size: 24px;
-    margin-bottom: 20px;
-    text-align: center;
-}
-
-/* Form styling */
-form {
-    background-color: #fff;
-    border-radius: 5px;
-    padding: 20px;
-    max-width: 500px;
-    margin: 0 auto;
-}
-
-label {
-    display: block;
-    margin-bottom: 5px;
-    font-weight: bold;
-}
-
-input[type="password"],
-input[type="text"] {
-    width: 100%;
-    padding: 10px;
-    margin-bottom: 20px;
-    border: 1px solid #ccc;
-    border-radius: 3px;
-}
-
-fieldset {
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    padding: 10px;
-    margin-bottom: 20px;
-}
-
-legend {
-    padding: 0 5px;
-}
-
-input[type="radio"] {
-    margin-right: 5px;
-}
-
-input[type="radio"] + label {
-    display: inline-block;
-    margin-bottom: 10px;
-    font-weight: normal;
-}
-
-button[type="submit"] {
-    background-color: #007bff;
-    color: #fff;
-    padding: 10px 20px;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    font-size: 16px;
-}
-
-button[type="submit"]:hover {
-    background-color: #0056b3;
-}
-
-.input-with-link {
-    display: flex;
-    align-items: center;
-    margin-bottom: 20px;
-}
-
-.input-with-link input[type="password"],
-.input-with-link input[type="text"] {
-    flex: 1;
-    margin-bottom: 0;
-}
-
-.toggle-visibility {
-    margin-left: 8px;
-    cursor: pointer;
-    user-select: none;
-}
-
-.status-icon {
-    margin-left: 8px;
-    font-size: 1.2em;
-}
-
-.custom-alert {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.5);
-    display: flex;
-    align-items: flex-start;
-    /*justify-content: center;*/
-    visibility: hidden;
-    padding-top: 20%;
-}
-
-.custom-alert .alert-content {
-    position: fixed;
-    left: 50%;
-    top: 20%;
-    transform: translate(-50%, -50%);
-    background-color: white;
-    padding: 20px;
-    border-radius: 5px;
-    /*text-align: center;*/
-}
-
-.toast {
-    position: fixed;
-    z-index: 999;
-    left: 50%;
-    top: 20%;
-    transform: translate(-50%, -50%);
-    background-color: #fff;
-    border: 1px solid #ccc;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
-    padding: 20px;
-    max-width: 400px;
-}
-
-.toast-message {
-    font-size: 18px;
-    text-align: center;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background: var(--light-bg);
+  color: var(--light-text);
+  padding: 20px;
 }
 
 @media (prefers-color-scheme: dark) {
-    body {
-        color: #eee;
-        background-color: #121212;
-    }
-    form {
-        background-color: #1e1e1e;
-    }
-    input[type="password"],
-    input[type="text"] {
-        background-color: #2b2b2b;
-        color: #eee;
-        border: 1px solid #555;
-    }
-    fieldset {
-        border-color: #555;
-    }
-    button[type="submit"] {
-        background-color: #4a90e2;
-        color: #fff;
-    }
-    button[type="submit"]:hover {
-        background-color: #357ab8;
-    }
-    .custom-alert {
-        background-color: rgba(0, 0, 0, 0.7);
-    }
-    .custom-alert .alert-content {
-        background-color: #1e1e1e;
-        color: #eee;
-    }
-    .toast {
-        background-color: #1e1e1e;
-        border: 1px solid #555;
-        box-shadow: 0 0 10px rgba(0, 0, 0, 0.8);
-    }
+  body {
+    background: var(--dark-bg);
+    color: var(--dark-text);
+  }
 }
 
+#options-form {
+  max-width: 600px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
 
+fieldset {
+  border: 0;
+  border-top: 1px solid var(--light-border);
+  padding: 20px 0 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+@media (prefers-color-scheme: dark) {
+  fieldset {
+    border-top-color: var(--dark-border);
+  }
+}
+
+label {
+  font-weight: 600;
+}
+
+input,
+select,
+textarea,
+button {
+  width: 100%;
+  padding: 10px;
+  border-radius: 6px;
+  border: 1px solid var(--light-border);
+  background: var(--light-bg);
+  color: var(--light-text);
+}
+
+@media (prefers-color-scheme: dark) {
+  input,
+  select,
+  textarea,
+  button {
+    background: #1f2c34;
+    color: var(--dark-text);
+    border-color: var(--dark-border);
+  }
+}
+
+button {
+  background: var(--whats-green);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+
+button:hover {
+  opacity: 0.9;
+}
+
+.input-group {
+  display: flex;
+  align-items: center;
+}
+
+.input-group input {
+  flex: 1;
+}
+
+.eye-icon {
+  background: none;
+  border: none;
+  margin-left: 8px;
+  padding: 0 6px;
+  cursor: pointer;
+  color: inherit;
+}
+
+.feedback {
+  display: none;
+  padding: 8px;
+  border-radius: 6px;
+  font-size: 0.9em;
+}
+
+.feedback.success {
+  display: block;
+  background: #d4f8e8;
+  color: #1a7f37;
+}
+
+.feedback.error {
+  display: block;
+  background: #ffd7d7;
+  color: #a61b29;
+}
+
+@media (prefers-color-scheme: dark) {
+  .feedback.success {
+    background: #054f2c;
+    color: #d4f8e8;
+  }
+  .feedback.error {
+    background: #6f1a1a;
+    color: #ffd7d7;
+  }
+}
+
+.helper {
+  font-size: 0.85em;
+  color: #667781;
+}
+
+@media (prefers-color-scheme: dark) {
+  .helper {
+    color: #8696a0;
+  }
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -9,86 +9,47 @@
 <body>
 <h1>Options for GPT answer-suggestions</h1>
 
-<div id="options-container">
-  <!-- Warning moved to top for visibility (from V5) -->
-  <div id="chatHistoryWarningAlert" class="custom-alert">
-      <div class="alert-content">
-          <div>
-              <p>The last messages of your chat-conversation will be sent to the selected AI provider automatically,
-                 each time you select another user, <br> or when a message comes into the currently selected conversation.<br>
-                 They are kept and used according to that provider's API documentation and privacy policy.<br>
-                 This is less secure than the end-to-end encryption that
-                 <a href="https://faq.whatsapp.com/820124435853543/?helpref=uf_share" target="_blank">WhatsApp™ uses</a>.<br></p>
-          </div>
-          <div style="text-align: center;">
-              <p><strong><span style="color: red;">Beware to leave this off in sensitive conversations!</span></strong></p>
-              <button type="submit" id="hideHistoryWarningAlert">I understand</button>
-          </div>
+  <div id="options-container">
+    <form id="options-form">
+    <fieldset id="provider-settings">
+      <legend>Provider Settings</legend>
+      <label for="api-choice">Provider</label>
+      <select id="api-choice" name="api-choice">
+        <option value="openai">OpenAI</option>
+        <option value="openrouter">OpenRouter</option>
+        <option value="anthropic">Anthropic</option>
+        <option value="mistral">Mistral</option>
+      </select>
+      <label for="api-key">API Key</label>
+        <div class="input-group">
+        <input type="password" id="api-key" name="api-key" aria-describedby="api-key-feedback">
+        <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">👁</button>
       </div>
-  </div>
-
-  <form id="options-form">
-    <fieldset>
-        <legend>Trigger chat answers from GPT:</legend>
-        <input type="radio" id="send-history-auto" name="send-history" value="auto">
-        <label for="send-history-auto">Automatically</label><br>
-        <input type="radio" id="send-history-manual" name="send-history" value="manual">
-        <label for="send-history-manual">Manually (Button)</label>
+      <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
+      <label for="model-name">Model Name</label>
+      <input type="text" id="model-name" name="model-name" placeholder="e.g. gpt-4o, claude-3-sonnet-20240229, mistral-large, etc.">
+      <p class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</p>
     </fieldset>
 
     <fieldset>
-        <legend>Choose API:</legend>
-        <label for="api-choice">Provider:</label>
-        <select id="api-choice" name="api-choice">
-            <option value="openai">OpenAI</option>
-            <option value="openrouter">OpenRouter</option>
-            <option value="claude">Claude (Anthropic)</option>
-            <option value="mistral">Mistral</option>
-        </select>
-        <label for="model-choice" style="margin-top:10px;">Model:</label>
-        <select id="model-choice" name="model-choice">
-            <option value="gpt-4o">OpenAI gpt-4o</option>
-            <option value="gpt-4o-mini">OpenAI gpt-4o-mini</option>
-            <option value="gpt-4o-nano">OpenAI gpt-4o-nano</option>
-            <option value="gpt-3.5-turbo">OpenAI gpt-3.5-turbo</option>
-        </select>
+      <legend>System Instructions</legend>
+      <div>
+        <label for="prompt-template">System Instructions</label>
+        <textarea id="prompt-template" name="prompt-template" rows="12" style="width: 100%;"></textarea>
+      </div>
     </fieldset>
 
     <fieldset>
-        <legend>API Key:</legend>
-        <label for="api-key">API Key:</label>
-        <input type="password" id="api-key" name="api-key">
-        <button type="button" id="toggle-api-key">Show</button>
-        <span id="api-key-status"></span>
-    </fieldset>
-
-    <fieldset>
-        <legend>Prompt:</legend>
-        <div>
-            <label for="prompt-template">Base prompt used to generate replies:</label>
-            <textarea id="prompt-template" name="prompt-template" rows="12" style="width: 100%;"></textarea>
-        </div>
-    </fieldset>
-
-    <fieldset>
-        <legend>Tone of Voice:</legend>
-        <div>
-            <label for="tone-of-voice">This is only the tone of voice you want to use, it will be inserted into the system prompt:</label>
-            <input type="text" id="tone-of-voice" name="tone-of-voice">
-        </div>
-    </fieldset>
-
-    <fieldset>
-        <legend>Improve My Response</legend>
-        <label>
-            <input type="checkbox" id="show-advanced-improve">
-            Show Advanced options for Improve-My-Response button
-        </label>
+      <legend>Improve My Response</legend>
+      <label>
+        <input type="checkbox" id="show-advanced-improve">
+        Show Advanced options for Improve-My-Response button
+      </label>
     </fieldset>
 
     <button type="submit">Save</button>
     <div class="toast" style="display:none">
-        <p>Options saved successfully!</p>
+      <p>Options saved successfully!</p>
     </div>
   </form>
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,8 +13,7 @@ Follow these rules:
 - Do not ask redundant questions already answered in the conversation.
 - Maintain grammatical correctness and natural language style.
 - Keep replies friendly and human-like without sounding overly formal unless the conversation tone requires it.
-- Do not add extra explanation, metadata, or reasoning—only output the suggested reply text(s).
-- If instructed in the tone-of-voice setting, adapt word choice, formality, and style accordingly.`;
+- Do not add extra explanation, metadata, or reasoning—only output the suggested reply text(s).`;
 
 export function strToBuf(str) {
   return new TextEncoder().encode(str);


### PR DESCRIPTION
## Summary
- Refresh options page with provider dropdown, per-provider API keys, and model name text field
- Remove automatic send feature and tone-of-voice setting; rename prompt section to System Instructions
- Style settings with WhatsApp-like theme and update background logic for provider defaults

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893a01ba65883208be99acdeb271ae0