### PR TITLE
Refine options UI for WhatsApp GPT extension

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,5 @@
 // background.js - version 2025-08-05T00:44:54Z
-import {b64ToBuf, fetchWithRetry, showToast} from './utils.js';
+import {b64ToBuf, fetchWithRetry, showToast, getDefaultModel} from './utils.js';
 import {logToGitHub} from './logger.js';
 
 const CONTENT_SCRIPTS = ['parser.js', 'uiStuff.js', 'confirmDialog.js', 'improveDialog.js', 'contentScript.js'];
@@ -160,20 +160,6 @@ async function sendLLM(prompt, tabId) {
     chrome.tabs.sendMessage(tabId, {type: 'error', data: err.message});
     showToast(err.message);
     logToGitHub(`LLM request failed: ${err.message}\n${err.stack || ''}`).catch(() => {});
-  }
-}
-
-function getDefaultModel(provider) {
-  switch (provider) {
-    case 'openrouter':
-    case 'openai':
-      return 'gpt-3.5-turbo';
-    case 'anthropic':
-      return 'claude-3-haiku-20240307';
-    case 'mistral':
-      return 'mistral-small';
-    default:
-      return '';
   }
 }
 

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -83,52 +83,108 @@ button:hover {
   opacity: 0.9;
 }
 
-.input-group {
+/* Provider and model row */
+.provider-model-row {
   display: flex;
-  align-items: center;
+  gap: 10px;
+}
+
+.provider-col {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+#api-choice {
+  width: auto;
+}
+
+.model-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+/* API key input */
+.input-group {
+  position: relative;
 }
 
 .input-group input {
-  flex: 1;
+  padding-right: 2.5rem;
 }
 
 .eye-icon {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
   background: none;
   border: none;
-  margin-left: 8px;
-  padding: 0 6px;
+  padding: 0;
   cursor: pointer;
   color: inherit;
 }
 
 .feedback {
   display: none;
-  padding: 8px;
-  border-radius: 6px;
-  font-size: 0.9em;
+  font-size: 0.85em;
+  margin-top: 4px;
 }
 
 .feedback.success {
-  display: block;
-  background: #d4f8e8;
   color: #1a7f37;
 }
 
 .feedback.error {
-  display: block;
-  background: #ffd7d7;
   color: #a61b29;
 }
 
+input.success {
+  border-color: #1a7f37;
+}
+
+input.error {
+  border-color: #a61b29;
+}
+
 @media (prefers-color-scheme: dark) {
+  input.success {
+    border-color: #1a7f37;
+  }
+  input.error {
+    border-color: #a61b29;
+  }
   .feedback.success {
-    background: #054f2c;
     color: #d4f8e8;
   }
   .feedback.error {
-    background: #6f1a1a;
     color: #ffd7d7;
   }
+}
+
+/* Improve section */
+
+.improve-section {
+  border-top: 1px solid var(--light-border);
+  padding: 20px 0 0 0;
+}
+
+.improve-section label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .improve-section {
+    border-top-color: var(--dark-border);
+  }
+}
+
+#system-instructions {
+  padding-top: 10px;
+  gap: 5px;
 }
 
 .helper {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -13,39 +13,41 @@
     <form id="options-form">
     <fieldset id="provider-settings">
       <legend>Provider Settings</legend>
-      <label for="api-choice">Provider</label>
-      <select id="api-choice" name="api-choice">
-        <option value="openai">OpenAI</option>
-        <option value="openrouter">OpenRouter</option>
-        <option value="anthropic">Anthropic</option>
-        <option value="mistral">Mistral</option>
-      </select>
+      <div class="provider-model-row">
+        <div class="provider-col">
+          <label for="api-choice">Provider</label>
+          <select id="api-choice" name="api-choice">
+            <option value="openai">OpenAI</option>
+            <option value="openrouter">OpenRouter</option>
+            <option value="anthropic">Anthropic</option>
+            <option value="mistral">Mistral</option>
+          </select>
+        </div>
+        <div class="model-col">
+          <label for="model-name">Model Name</label>
+          <input type="text" id="model-name" name="model-name" placeholder="gpt-3.5-turbo">
+        </div>
+      </div>
+      <p class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</p>
       <label for="api-key">API Key</label>
-        <div class="input-group">
+      <div class="input-group">
         <input type="password" id="api-key" name="api-key" aria-describedby="api-key-feedback">
         <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">👁</button>
+        <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
       </div>
-      <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
-      <label for="model-name">Model Name</label>
-      <input type="text" id="model-name" name="model-name" placeholder="e.g. gpt-4o, claude-3-sonnet-20240229, mistral-large, etc.">
-      <p class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</p>
     </fieldset>
 
-    <fieldset>
+    <fieldset id="system-instructions">
       <legend>System Instructions</legend>
-      <div>
-        <label for="prompt-template">System Instructions</label>
-        <textarea id="prompt-template" name="prompt-template" rows="12" style="width: 100%;"></textarea>
-      </div>
+      <textarea id="prompt-template" name="prompt-template" rows="12" style="width: 100%;"></textarea>
     </fieldset>
 
-    <fieldset>
-      <legend>Improve My Response</legend>
-      <label>
+    <div id="improve-section" class="improve-section">
+      <label for="show-advanced-improve">
         <input type="checkbox" id="show-advanced-improve">
         Show Advanced options for Improve-My-Response button
       </label>
-    </fieldset>
+    </div>
 
     <button type="submit">Save</button>
     <div class="toast" style="display:none">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,4 +1,4 @@
-import {strToBuf, bufToB64, b64ToBuf, DEFAULT_PROMPT} from '../utils.js';
+import {strToBuf, bufToB64, b64ToBuf, DEFAULT_PROMPT, getDefaultModel} from '../utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   restoreOptions();
@@ -39,12 +39,16 @@ toggleBtn.addEventListener('click', () => {
 function setFeedback(message, type) {
   feedbackBox.textContent = message;
   feedbackBox.classList.remove('success', 'error');
+  apiKeyInput.classList.remove('success', 'error');
   if (!message) {
     feedbackBox.style.display = 'none';
     return;
   }
   feedbackBox.style.display = 'block';
-  if (type) feedbackBox.classList.add(type);
+  if (type) {
+    feedbackBox.classList.add(type);
+    apiKeyInput.classList.add(type);
+  }
 }
 
 async function getOrCreateEncKey() {
@@ -143,6 +147,7 @@ async function saveOptions(e) {
 async function loadProviderFields(provider) {
   apiKeyInput.value = '';
   modelInput.value = modelNames[provider] || '';
+  modelInput.placeholder = getDefaultModel(provider);
   if (!apiKeys[provider] || !encKeyB64) return;
   try {
     const key = await crypto.subtle.importKey('raw', b64ToBuf(encKeyB64), 'AES-GCM', false, ['decrypt']);

--- a/src/utils.js
+++ b/src/utils.js
@@ -63,6 +63,20 @@ export async function fetchWithRetry(
   }
 }
 
+export function getDefaultModel(provider) {
+  switch (provider) {
+    case 'openrouter':
+    case 'openai':
+      return 'gpt-3.5-turbo';
+    case 'anthropic':
+      return 'claude-3-haiku-20240307';
+    case 'mistral':
+      return 'mistral-small';
+    default:
+      return '';
+  }
+}
+
 export function showToast(message) {
   if (typeof window !== 'undefined' && window.document && document.body) {
     const toast = document.createElement('div');


### PR DESCRIPTION
## Summary
- Align provider selector with model input on a single row and use provider-specific default models as placeholders
- Integrate API key eye toggle and inline validation feedback styled after WhatsApp
- Streamline system and improve-response sections and centralize default model helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893a72936d88320adad930d80dc9de3