### PR TITLE
Refine options page styling

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -22,9 +22,12 @@ body {
   }
 }
 
-#options-form {
+#options-container {
   max-width: 600px;
   margin: 0 auto;
+}
+
+#options-form {
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -47,6 +50,22 @@ fieldset {
 
 label {
   font-weight: 600;
+}
+
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0 0 20px 0;
+  color: inherit;
+}
+
+legend,
+h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: inherit;
+  margin-bottom: 10px;
+  padding: 0;
 }
 
 input,
@@ -87,16 +106,17 @@ button:hover {
 .provider-model-row {
   display: flex;
   gap: 10px;
+  align-items: center;
 }
 
 .provider-col {
-  flex: 0 0 auto;
+  flex: 0 0 160px;
   display: flex;
   flex-direction: column;
 }
 
 #api-choice {
-  width: auto;
+  width: 100%;
 }
 
 .model-col {
@@ -176,8 +196,23 @@ input.error {
   gap: 8px;
 }
 
+.improve-section input[type="checkbox"] {
+  width: auto;
+}
+
 @media (prefers-color-scheme: dark) {
   .improve-section {
+    border-top-color: var(--dark-border);
+  }
+}
+
+#history {
+  border-top: 1px solid var(--light-border);
+  padding: 20px 0 0 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  #history {
     border-top-color: var(--dark-border);
   }
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -11,49 +11,46 @@
 
   <div id="options-container">
     <form id="options-form">
-    <fieldset id="provider-settings">
-      <legend>Provider Settings</legend>
-      <div class="provider-model-row">
-        <div class="provider-col">
-          <label for="api-choice">Provider</label>
-          <select id="api-choice" name="api-choice">
-            <option value="openai">OpenAI</option>
-            <option value="openrouter">OpenRouter</option>
-            <option value="anthropic">Anthropic</option>
-            <option value="mistral">Mistral</option>
-          </select>
+      <fieldset id="provider-settings">
+        <legend>Provider Settings</legend>
+        <div class="provider-model-row">
+          <div class="provider-col">
+            <label for="api-choice">Provider</label>
+            <select id="api-choice" name="api-choice">
+              <option value="openai">OpenAI</option>
+              <option value="openrouter">OpenRouter</option>
+              <option value="anthropic">Anthropic</option>
+              <option value="mistral">Mistral</option>
+            </select>
+          </div>
+          <div class="model-col">
+            <label for="model-name">Model Name</label>
+            <input type="text" id="model-name" name="model-name" placeholder="gpt-3.5-turbo">
+            <p class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</p>
+          </div>
         </div>
-        <div class="model-col">
-          <label for="model-name">Model Name</label>
-          <input type="text" id="model-name" name="model-name" placeholder="gpt-3.5-turbo">
+        <label for="api-key">API Key</label>
+        <div class="input-group">
+          <input type="password" id="api-key" name="api-key" aria-describedby="api-key-feedback">
+          <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">👁</button>
         </div>
-      </div>
-      <p class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</p>
-      <label for="api-key">API Key</label>
-      <div class="input-group">
-        <input type="password" id="api-key" name="api-key" aria-describedby="api-key-feedback">
-        <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">👁</button>
         <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
+      </fieldset>
+
+      <fieldset id="system-instructions">
+        <legend>System Instructions</legend>
+        <textarea id="prompt-template" name="prompt-template" rows="12" style="width: 100%;"></textarea>
+      </fieldset>
+
+      <div id="improve-section" class="improve-section">
+        <label for="show-advanced-improve">
+          <input type="checkbox" id="show-advanced-improve">
+          Show Advanced options for Improve-My-Response button
+        </label>
       </div>
-    </fieldset>
 
-    <fieldset id="system-instructions">
-      <legend>System Instructions</legend>
-      <textarea id="prompt-template" name="prompt-template" rows="12" style="width: 100%;"></textarea>
-    </fieldset>
-
-    <div id="improve-section" class="improve-section">
-      <label for="show-advanced-improve">
-        <input type="checkbox" id="show-advanced-improve">
-        Show Advanced options for Improve-My-Response button
-      </label>
-    </div>
-
-    <button type="submit">Save</button>
-    <div class="toast" style="display:none">
-      <p>Options saved successfully!</p>
-    </div>
-  </form>
+      <button type="submit" id="save-button">Save</button>
+    </form>
 
   <div id="history">
     <h2>LLM Call History</h2>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -12,6 +12,7 @@ const apiKeyInput = document.getElementById('api-key');
 const modelInput = document.getElementById('model-name');
 const toggleBtn = document.getElementById('toggle-api-key');
 const feedbackBox = document.getElementById('api-key-feedback');
+const saveBtn = document.getElementById('save-button');
 
 let apiKeys = {};
 let modelNames = {};
@@ -93,9 +94,9 @@ async function validateApiKey() {
   }
   try {
     const res = await fetch(url, {headers});
-    setFeedback(res.ok ? 'Key verified' : 'Key not verified', res.ok ? 'success' : 'error');
+    setFeedback(res.ok ? 'Key verified' : 'Invalid key', res.ok ? 'success' : 'error');
   } catch {
-    setFeedback('Key not verified', 'error');
+    setFeedback('Error verifying key', 'error');
   }
 }
 
@@ -135,11 +136,10 @@ async function saveOptions(e) {
     if (showAdvancedImprove && !prev.showAdvancedImprove) {
       refreshWhatsAppTabs();
     }
-    const alertBox = document.querySelector('.toast');
-    alertBox.style.display = 'block';
+    const original = saveBtn.textContent;
+    saveBtn.textContent = 'Saved';
     setTimeout(() => {
-      alertBox.style.display = 'none';
-      window.close();
+      saveBtn.textContent = original;
     }, 2000);
   });
 }


### PR DESCRIPTION
## Summary
- Standardize headings and section layouts for WhatsApp-like appearance
- Align provider/model/API key fields with inline helper and feedback text
- Show save confirmation inside button and tidy advanced options section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893adc1c4d88320bc1792923ef06021