### PR TITLE
Revamp settings and history layout

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -23,14 +23,37 @@ body {
 }
 
 #options-container {
-  max-width: 600px;
-  margin: 0 auto;
+  display: flex;
+  height: calc(100vh - 40px);
+}
+
+#settings-panel {
+  flex: 0 0 25%;
+  padding-right: 20px;
+  border-right: 1px solid var(--light-border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+@media (prefers-color-scheme: dark) {
+  #settings-panel {
+    border-right-color: var(--dark-border);
+  }
 }
 
 #options-form {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  flex: 1;
+}
+
+#history-panel {
+  flex: 1;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
 }
 
 fieldset {
@@ -91,26 +114,33 @@ button {
   }
 }
 
-button {
+.primary-button {
+  width: auto;
+  padding: 10px 20px;
   background: var(--whats-green);
   color: #fff;
   border: none;
   cursor: pointer;
+  border-radius: 6px;
 }
 
-button:hover {
+.primary-button:hover {
   opacity: 0.9;
+}
+
+#save-button {
+  align-self: center;
 }
 
 /* Provider and model row */
 .provider-model-row {
   display: flex;
   gap: 10px;
-  align-items: center;
+  align-items: flex-start;
 }
 
 .provider-col {
-  flex: 0 0 160px;
+  flex: 0 0 40%;
   display: flex;
   flex-direction: column;
 }
@@ -144,6 +174,22 @@ button:hover {
   padding: 0;
   cursor: pointer;
   color: inherit;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.eye-icon img {
+  width: 24px;
+  height: 24px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .eye-icon img {
+    filter: invert(1);
+  }
 }
 
 .feedback {
@@ -206,14 +252,38 @@ input.error {
   }
 }
 
-#history {
-  border-top: 1px solid var(--light-border);
-  padding: 20px 0 0 0;
+#history-panel {
+  overflow: hidden;
+}
+
+#history-panel .history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.history-table-wrapper {
+  flex: 1;
+  overflow: auto;
+}
+
+#history-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#history-table th,
+#history-table td {
+  text-align: left;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--light-border);
 }
 
 @media (prefers-color-scheme: dark) {
-  #history {
-    border-top-color: var(--dark-border);
+  #history-table th,
+  #history-table td {
+    border-bottom-color: var(--dark-border);
   }
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -9,7 +9,8 @@
 <body>
 <h1>Options for GPT answer-suggestions</h1>
 
-  <div id="options-container">
+<div id="options-container">
+  <div id="settings-panel">
     <form id="options-form">
       <fieldset id="provider-settings">
         <legend>Provider Settings</legend>
@@ -32,7 +33,9 @@
         <label for="api-key">API Key</label>
         <div class="input-group">
           <input type="password" id="api-key" name="api-key" aria-describedby="api-key-feedback">
-          <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">👁</button>
+          <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">
+            <img src="../icons/Eye Icon - Show Password.svg" alt="">
+          </button>
         </div>
         <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
       </fieldset>
@@ -49,27 +52,30 @@
         </label>
       </div>
 
-      <button type="submit" id="save-button">Save</button>
+      <button type="submit" id="save-button" class="primary-button">Save</button>
     </form>
+  </div>
 
-  <div id="history">
-    <h2>LLM Call History</h2>
-    <table id="history-table">
-      <thead>
-        <tr>
-          <th>Timestamp</th>
-          <th>Provider</th>
-          <th>Model</th>
-          <th>Prompt</th>
-          <th>Prompt Tokens</th>
-          <th>Completion Tokens</th>
-          <th>Total Tokens</th>
-          <th>Response Time (ms)</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-    <button id="download-csv">Download CSV</button>
+  <div id="history-panel">
+    <div class="history-header">
+      <h2>LLM Call History</h2>
+      <button id="download-csv" class="primary-button">Download CSV</button>
+    </div>
+    <div class="history-table-wrapper">
+      <table id="history-table">
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>Model</th>
+            <th>Chat History</th>
+            <th>Completion Tokens</th>
+            <th>Total Tokens</th>
+            <th>Response Time (ms)</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </div>
 </div>
 

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -11,6 +11,9 @@ const apiChoiceSelect = document.getElementById('api-choice');
 const apiKeyInput = document.getElementById('api-key');
 const modelInput = document.getElementById('model-name');
 const toggleBtn = document.getElementById('toggle-api-key');
+const eyeImg = toggleBtn.querySelector('img');
+const showIcon = '../icons/Eye Icon - Show Password.svg';
+const hideIcon = '../icons/Eye Icon - Hide Password.svg';
 const feedbackBox = document.getElementById('api-key-feedback');
 const saveBtn = document.getElementById('save-button');
 
@@ -33,7 +36,7 @@ apiKeyInput.addEventListener('input', () => {
 toggleBtn.addEventListener('click', () => {
   const isText = apiKeyInput.type === 'text';
   apiKeyInput.type = isText ? 'password' : 'text';
-  toggleBtn.textContent = isText ? '👁' : '🙈';
+  eyeImg.src = isText ? showIcon : hideIcon;
   toggleBtn.setAttribute('aria-label', isText ? 'Show API key' : 'Hide API key');
 });
 
@@ -186,10 +189,8 @@ async function renderHistory() {
     const tr = document.createElement('tr');
     const cells = [
       new Date(item.timestamp).toLocaleString(),
-      item.provider,
       item.model,
       item.prompt,
-      item.tokensPrompt,
       item.tokensCompletion,
       item.tokensTotal,
       item.responseTime
@@ -205,15 +206,13 @@ async function renderHistory() {
 
 async function downloadCsv() {
   const {history = []} = await chrome.storage.local.get({history: []});
-  const headers = ['timestamp','provider','model','prompt','tokensPrompt','tokensCompletion','tokensTotal','responseTime'];
+  const headers = ['timestamp','model','prompt','tokensCompletion','tokensTotal','responseTime'];
   let csv = headers.join(',') + '\n';
   for (const item of history) {
     const row = [
       new Date(item.timestamp).toISOString(),
-      item.provider,
       item.model,
       item.prompt,
-      item.tokensPrompt,
       item.tokensCompletion,
       item.tokensTotal,
       item.responseTime


### PR DESCRIPTION
## Summary
- Restructured options page into split layout with a left settings pane and right history pane.
- Added show/hide API key icons, compact CTA buttons, and updated history table columns.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893b8b0acd08320b665f2a87a0d9351