### PR TITLE
feat: redesign options UI

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,106 +1,141 @@
 :root {
-  --whats-green: #25d366;
-  --light-bg: #fff;
-  --light-text: #111b21;
-  --light-border: #ddd;
-  --dark-bg: #111b21;
-  --dark-text: #e9edef;
-  --dark-border: #23272b;
+  --wa-bg-light: #f0f2f5;
+  --wa-bg-main-light: #fff;
+  --wa-nav-text-light: #222e35;
+  --wa-nav-subtitle-light: #8696a0;
+  --wa-divider-light: #e9edef;
+  --wa-selected-nav-light: #e9edef;
+  --wa-accent: #25d366;
+
+  --wa-bg-dark: #202c33;
+  --wa-bg-main-dark: #111b21;
+  --wa-nav-text-dark: #e9edef;
+  --wa-nav-subtitle-dark: #8696a0;
+  --wa-divider-dark: #2a3942;
+  --wa-selected-nav-dark: #2a3942;
 }
 
 body {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-  background: var(--light-bg);
-  color: var(--light-text);
-  padding: 20px;
+  margin: 0;
+  font-family: "Segoe UI", "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  color: var(--wa-nav-text-light);
+  background: var(--wa-bg-light);
+  font-size: 16px;
 }
 
 @media (prefers-color-scheme: dark) {
   body {
-    background: var(--dark-bg);
-    color: var(--dark-text);
+    color: var(--wa-nav-text-dark);
+    background: var(--wa-bg-dark);
   }
 }
 
-#options-container {
+.options-container {
   display: flex;
-  height: calc(100vh - 40px);
+  min-height: 100vh;
 }
 
-#settings-panel {
-  flex: 0 0 25%;
-  padding-right: 20px;
-  border-right: 1px solid var(--light-border);
-  display: flex;
-  flex-direction: column;
+.sidebar {
+  width: 320px;
+  background: var(--wa-bg-light);
+  border-right: 1px solid var(--wa-divider-light);
   overflow-y: auto;
 }
 
 @media (prefers-color-scheme: dark) {
-  #settings-panel {
-    border-right-color: var(--dark-border);
+  .sidebar {
+    background: var(--wa-bg-dark);
+    border-right-color: var(--wa-divider-dark);
   }
 }
 
-#options-form {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  flex: 1;
+.sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
-#history-panel {
-  flex: 1;
-  padding-left: 20px;
+.nav-item {
+  width: 100%;
+  padding: 16px 24px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: var(--wa-nav-text-light);
   display: flex;
   flex-direction: column;
 }
 
-fieldset {
-  border: 0;
-  border-top: 1px solid var(--light-border);
-  padding: 20px 0 0 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+.nav-item:hover {
+  background: var(--wa-selected-nav-light);
+}
+
+.nav-item.active {
+  background: var(--wa-selected-nav-light);
+  font-weight: 600;
+}
+
+.nav-title {
+  font-size: 16px;
+}
+
+.nav-subtitle {
+  font-size: 13px;
+  color: var(--wa-nav-subtitle-light);
 }
 
 @media (prefers-color-scheme: dark) {
-  fieldset {
-    border-top-color: var(--dark-border);
+  .nav-item {
+    color: var(--wa-nav-text-dark);
+  }
+  .nav-subtitle {
+    color: var(--wa-nav-subtitle-dark);
+  }
+  .nav-item:hover,
+  .nav-item.active {
+    background: var(--wa-selected-nav-dark);
   }
 }
 
-label {
-  font-weight: 600;
+.main-content {
+  flex: 1;
+  background: var(--wa-bg-main-light);
+  padding: 32px;
+  overflow: auto;
 }
 
-h1 {
-  font-size: 1.5rem;
-  font-weight: 600;
-  margin: 0 0 20px 0;
-  color: inherit;
+@media (prefers-color-scheme: dark) {
+  .main-content {
+    background: var(--wa-bg-main-dark);
+  }
 }
 
-legend,
-h2 {
-  font-size: 1.25rem;
+.page-title {
+  font-size: 24px;
   font-weight: 600;
-  color: inherit;
-  margin-bottom: 10px;
-  padding: 0;
+  margin: 0 0 24px 0;
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
 }
 
 input,
 select,
 textarea,
 button {
-  width: 100%;
   padding: 10px;
   border-radius: 6px;
-  border: 1px solid var(--light-border);
-  background: var(--light-bg);
-  color: var(--light-text);
+  border: 1px solid var(--wa-divider-light);
+  background: var(--wa-bg-main-light);
+  color: var(--wa-nav-text-light);
+  font-family: inherit;
+  font-size: 15px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -108,77 +143,73 @@ button {
   select,
   textarea,
   button {
-    background: #1f2c34;
-    color: var(--dark-text);
-    border-color: var(--dark-border);
+    background: var(--wa-bg-main-dark);
+    color: var(--wa-nav-text-dark);
+    border-color: var(--wa-divider-dark);
   }
 }
 
 .primary-button {
-  width: auto;
-  padding: 10px 20px;
-  background: var(--whats-green);
+  background: var(--wa-accent);
   color: #fff;
   border: none;
   cursor: pointer;
+  padding: 10px 20px;
   border-radius: 6px;
+  width: auto;
 }
 
-.primary-button:hover {
-  opacity: 0.9;
-}
-
-#save-button {
-  align-self: center;
-}
-
-/* Provider and model row */
-.provider-model-row {
+.history-header {
   display: flex;
-  gap: 10px;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: flex-end;
+  margin-bottom: 16px;
 }
 
-.provider-col {
-  flex: 0 0 40%;
-  display: flex;
-  flex-direction: column;
+.history-table-wrapper {
+  overflow: auto;
 }
 
-#api-choice {
+#history-table {
   width: 100%;
+  border-collapse: collapse;
 }
 
-.model-col {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
+#history-table th,
+#history-table td {
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid var(--wa-divider-light);
 }
 
-/* API key input */
+@media (prefers-color-scheme: dark) {
+  #history-table th,
+  #history-table td {
+    border-bottom-color: var(--wa-divider-dark);
+  }
+}
+
+.helper {
+  font-size: 13px;
+  color: var(--wa-nav-subtitle-light);
+}
+
+@media (prefers-color-scheme: dark) {
+  .helper {
+    color: var(--wa-nav-subtitle-dark);
+  }
+}
+
 .input-group {
-  position: relative;
-}
-
-.input-group input {
-  padding-right: 2.5rem;
+  display: flex;
+  align-items: center;
 }
 
 .eye-icon {
-  position: absolute;
-  top: 50%;
-  right: 8px;
-  transform: translateY(-50%);
   background: none;
   border: none;
-  padding: 0;
   cursor: pointer;
-  color: inherit;
-  width: 24px;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  padding-left: 8px;
 }
 
 .eye-icon img {
@@ -186,15 +217,9 @@ button {
   height: 24px;
 }
 
-@media (prefers-color-scheme: dark) {
-  .eye-icon img {
-    filter: invert(1);
-  }
-}
-
 .feedback {
   display: none;
-  font-size: 0.85em;
+  font-size: 13px;
   margin-top: 4px;
 }
 
@@ -215,90 +240,91 @@ input.error {
 }
 
 @media (prefers-color-scheme: dark) {
-  input.success {
-    border-color: #1a7f37;
-  }
-  input.error {
-    border-color: #a61b29;
-  }
   .feedback.success {
     color: #d4f8e8;
   }
   .feedback.error {
     color: #ffd7d7;
   }
+  input.success {
+    border-color: #1a7f37;
+  }
+  input.error {
+    border-color: #a61b29;
+  }
 }
 
-/* Improve section */
+.provider-model-row {
+  display: flex;
+  gap: 10px;
+}
+
+.provider-col {
+  flex: 1;
+}
+
+.model-col {
+  flex: 2;
+}
+
+fieldset {
+  border: 0;
+  border-top: 1px solid var(--wa-divider-light);
+  padding: 20px 0 0 0;
+  margin: 0 0 20px 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  fieldset {
+    border-top-color: var(--wa-divider-dark);
+  }
+}
+
+label {
+  font-weight: 600;
+}
 
 .improve-section {
-  border-top: 1px solid var(--light-border);
+  border-top: 1px solid var(--wa-divider-light);
   padding: 20px 0 0 0;
-}
-
-.improve-section label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.improve-section input[type="checkbox"] {
-  width: auto;
 }
 
 @media (prefers-color-scheme: dark) {
   .improve-section {
-    border-top-color: var(--dark-border);
+    border-top-color: var(--wa-divider-dark);
   }
 }
 
-#history-panel {
-  overflow: hidden;
+.menu-toggle {
+  display: none;
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  background: var(--wa-accent);
+  color: #fff;
+  border: none;
+  padding: 8px;
+  border-radius: 4px;
+  z-index: 30;
 }
 
-#history-panel .history-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 10px;
-}
-
-.history-table-wrapper {
-  flex: 1;
-  overflow: auto;
-}
-
-#history-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-#history-table th,
-#history-table td {
-  text-align: left;
-  padding: 6px 8px;
-  border-bottom: 1px solid var(--light-border);
-}
-
-@media (prefers-color-scheme: dark) {
-  #history-table th,
-  #history-table td {
-    border-bottom-color: var(--dark-border);
+@media (max-width: 600px) {
+  .options-container {
+    flex-direction: column;
   }
-}
-
-#system-instructions {
-  padding-top: 10px;
-  gap: 5px;
-}
-
-.helper {
-  font-size: 0.85em;
-  color: #667781;
-}
-
-@media (prefers-color-scheme: dark) {
-  .helper {
-    color: #8696a0;
+  .sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    height: 100%;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 20;
+  }
+  .sidebar.open {
+    transform: translateX(0);
+  }
+  .menu-toggle {
+    display: block;
   }
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,84 +1,133 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="options.css">
-    <title>ChatGPT Options</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="options.css">
+  <title>ChatGPT Options</title>
 </head>
 <body>
-<h1>Options for GPT answer-suggestions</h1>
+  <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
+  <div class="options-container">
+    <nav id="sidebar" class="sidebar" aria-label="Main">
+      <ul>
+        <li><button class="nav-item active" data-tab="settings" aria-current="page">
+          <span class="nav-title">Settings</span>
+          <span class="nav-subtitle">Provider &amp; model</span>
+        </button></li>
+        <li><button class="nav-item" data-tab="history">
+          <span class="nav-title">Logs / History</span>
+          <span class="nav-subtitle">LLM call log</span>
+        </button></li>
+        <li><button class="nav-item" data-tab="guide">
+          <span class="nav-title">User Guide</span>
+          <span class="nav-subtitle">How it works</span>
+        </button></li>
+        <li><button class="nav-item" data-tab="about">
+          <span class="nav-title">About</span>
+          <span class="nav-subtitle">Extension info</span>
+        </button></li>
+        <li><button class="nav-item" data-tab="bugs">
+          <span class="nav-title">Bug / Feature Request</span>
+          <span class="nav-subtitle">Send feedback</span>
+        </button></li>
+        <li><button class="nav-item" data-tab="help">
+          <span class="nav-title">Help</span>
+          <span class="nav-subtitle">Support</span>
+        </button></li>
+      </ul>
+    </nav>
+    <main id="main-content" class="main-content">
+      <section id="settings" class="tab-content active" role="tabpanel">
+        <h1 class="page-title">Settings</h1>
+        <form id="options-form">
+          <fieldset id="provider-settings">
+            <legend>Provider Settings</legend>
+            <div class="provider-model-row">
+              <div class="provider-col">
+                <label for="api-choice">Provider</label>
+                <select id="api-choice" name="api-choice">
+                  <option value="openai">OpenAI</option>
+                  <option value="openrouter">OpenRouter</option>
+                  <option value="anthropic">Anthropic</option>
+                  <option value="mistral">Mistral</option>
+                </select>
+              </div>
+              <div class="model-col">
+                <label for="model-name">Model Name</label>
+                <input type="text" id="model-name" name="model-name" placeholder="gpt-3.5-turbo">
+                <p class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</p>
+              </div>
+            </div>
+            <label for="api-key">API Key</label>
+            <div class="input-group">
+              <input type="password" id="api-key" name="api-key" aria-describedby="api-key-feedback">
+              <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">
+                <img src="../icons/Eye Icon - Show Password.svg" alt="">
+              </button>
+            </div>
+            <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
+          </fieldset>
 
-<div id="options-container">
-  <div id="settings-panel">
-    <form id="options-form">
-      <fieldset id="provider-settings">
-        <legend>Provider Settings</legend>
-        <div class="provider-model-row">
-          <div class="provider-col">
-            <label for="api-choice">Provider</label>
-            <select id="api-choice" name="api-choice">
-              <option value="openai">OpenAI</option>
-              <option value="openrouter">OpenRouter</option>
-              <option value="anthropic">Anthropic</option>
-              <option value="mistral">Mistral</option>
-            </select>
+          <fieldset id="system-instructions">
+            <legend>System Instructions</legend>
+            <textarea id="prompt-template" name="prompt-template" rows="12" style="width: 100%;"></textarea>
+          </fieldset>
+
+          <div id="improve-section" class="improve-section">
+            <label for="show-advanced-improve">
+              <input type="checkbox" id="show-advanced-improve">
+              Show Advanced options for Improve-My-Response button
+            </label>
           </div>
-          <div class="model-col">
-            <label for="model-name">Model Name</label>
-            <input type="text" id="model-name" name="model-name" placeholder="gpt-3.5-turbo">
-            <p class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</p>
-          </div>
+
+          <button type="submit" id="save-button" class="primary-button">Save</button>
+        </form>
+      </section>
+      <section id="history" class="tab-content" role="tabpanel">
+        <h1 class="page-title">Logs / History</h1>
+        <div class="history-header">
+          <button id="download-csv" class="primary-button">Download CSV</button>
         </div>
-        <label for="api-key">API Key</label>
-        <div class="input-group">
-          <input type="password" id="api-key" name="api-key" aria-describedby="api-key-feedback">
-          <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">
-            <img src="../icons/Eye Icon - Show Password.svg" alt="">
-          </button>
+        <div class="history-table-wrapper">
+          <table id="history-table">
+            <thead>
+              <tr>
+                <th>Timestamp</th>
+                <th>Model</th>
+                <th>Chat History</th>
+                <th>Completion Tokens</th>
+                <th>Total Tokens</th>
+                <th>Response Time (ms)</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
         </div>
-        <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
-      </fieldset>
-
-      <fieldset id="system-instructions">
-        <legend>System Instructions</legend>
-        <textarea id="prompt-template" name="prompt-template" rows="12" style="width: 100%;"></textarea>
-      </fieldset>
-
-      <div id="improve-section" class="improve-section">
-        <label for="show-advanced-improve">
-          <input type="checkbox" id="show-advanced-improve">
-          Show Advanced options for Improve-My-Response button
-        </label>
-      </div>
-
-      <button type="submit" id="save-button" class="primary-button">Save</button>
-    </form>
+      </section>
+      <section id="guide" class="tab-content" role="tabpanel">
+        <h1 class="page-title">User Guide</h1>
+        <p>Use the extension to generate AI suggested replies for your chats.</p>
+        <ol>
+          <li>Open WhatsApp Web.</li>
+          <li>Select a chat and type a message.</li>
+          <li>Click the AI button to receive suggestions.</li>
+        </ol>
+      </section>
+      <section id="about" class="tab-content" role="tabpanel">
+        <h1 class="page-title">About</h1>
+        <p>This open-source extension suggests replies using multiple AI providers.</p>
+      </section>
+      <section id="bugs" class="tab-content" role="tabpanel">
+        <h1 class="page-title">Bug / Feature Request</h1>
+        <p>Found an issue or have an idea? Visit our project page on <a href="https://github.com/" target="_blank" rel="noopener">GitHub</a> to open an issue.</p>
+      </section>
+      <section id="help" class="tab-content" role="tabpanel">
+        <h1 class="page-title">Help</h1>
+        <p>Check the <a href="https://chrome.google.com/webstore/detail/chatgpt-answers-for-whats/bmbidjjfpkmlddlbkljbphdgpnjnpogk" target="_blank" rel="noopener">extension listing</a> for details and support.</p>
+      </section>
+    </main>
   </div>
-
-  <div id="history-panel">
-    <div class="history-header">
-      <h2>LLM Call History</h2>
-      <button id="download-csv" class="primary-button">Download CSV</button>
-    </div>
-    <div class="history-table-wrapper">
-      <table id="history-table">
-        <thead>
-          <tr>
-            <th>Timestamp</th>
-            <th>Model</th>
-            <th>Chat History</th>
-            <th>Completion Tokens</th>
-            <th>Total Tokens</th>
-            <th>Response Time (ms)</th>
-          </tr>
-        </thead>
-        <tbody></tbody>
-      </table>
-    </div>
-  </div>
-</div>
-
-<script type="module" src="options.js"></script>
+  <script type="module" src="options.js"></script>
 </body>
 </html>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -3,6 +3,7 @@ import {strToBuf, bufToB64, b64ToBuf, DEFAULT_PROMPT, getDefaultModel} from '../
 document.addEventListener('DOMContentLoaded', () => {
   restoreOptions();
   renderHistory();
+  setupNavigation();
 });
 document.getElementById('options-form').addEventListener('submit', saveOptions);
 document.getElementById('download-csv').addEventListener('click', downloadCsv);
@@ -238,5 +239,40 @@ function refreshWhatsAppTabs() {
         }
       });
     }
+  });
+}
+
+function setupNavigation() {
+  const navItems = document.querySelectorAll('.nav-item');
+  const sections = document.querySelectorAll('.tab-content');
+  const sidebar = document.getElementById('sidebar');
+  const menuToggle = document.getElementById('menu-toggle');
+
+  function showTab(id) {
+    sections.forEach(sec => {
+      sec.classList.toggle('active', sec.id === id);
+    });
+    navItems.forEach(item => {
+      const active = item.dataset.tab === id;
+      item.classList.toggle('active', active);
+      if (active) {
+        item.setAttribute('aria-current', 'page');
+      } else {
+        item.removeAttribute('aria-current');
+      }
+    });
+  }
+
+  navItems.forEach(item => {
+    item.addEventListener('click', () => {
+      showTab(item.dataset.tab);
+      if (window.innerWidth <= 600) {
+        sidebar.classList.remove('open');
+      }
+    });
+  });
+
+  menuToggle.addEventListener('click', () => {
+    sidebar.classList.toggle('open');
   });
 }


### PR DESCRIPTION
## Summary
- style options page with WhatsApp-like sidebar and main pane
- add navigation tabs for settings, history and docs
- support light/dark modes and mobile drawer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68942c1e2af883209e3efdfc7860b12c