### PR TITLE
Align options panes and add extension branding

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -42,7 +42,8 @@ body {
 
 .options-container {
   display: flex;
-  min-height: 100vh;
+  height: 100vh;
+  align-items: stretch;
 }
 
 .icon-bar {
@@ -82,15 +83,28 @@ body {
   background: var(--divider-light);
 }
 
-.icon-avatar {
+.extension-branding {
   margin-top: auto;
-  padding: 8px;
+  padding: 12px 0;
+  text-align: center;
 }
 
-.icon-avatar img {
+.extension-icon {
   width: 32px;
   height: 32px;
   border-radius: 50%;
+}
+
+.extension-name {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #8696a0;
+}
+
+@media (prefers-color-scheme: dark) {
+  .extension-name {
+    color: #b1b9be;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -111,7 +125,7 @@ body {
   background: var(--sidebar-bg-light);
   border-right: 1px solid var(--divider-light);
   overflow-y: auto;
-  height: 100vh;
+  height: 100%;
   box-sizing: border-box;
 }
 
@@ -177,9 +191,9 @@ body {
 .main-content {
   flex: 1;
   background: var(--main-bg-light);
-  padding: 32px;
+  padding: 0 32px 32px;
   overflow: auto;
-  height: 100vh;
+  height: 100%;
   box-sizing: border-box;
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -18,8 +18,9 @@
         <li><button class="icon-item" data-tab="bugs" aria-label="Bug / Feature Request"><img src="../icons/Bug.svg" alt="Bug icon"></button></li>
         <li><button class="icon-item" data-tab="help" aria-label="Help"><img src="../icons/Help.svg" alt="Help icon"></button></li>
       </ul>
-      <div class="icon-avatar">
-        <img src="../Ext-Icon-1.png" alt="User avatar">
+      <div class="extension-branding">
+        <img src="../icons/icon_48.png" alt="Extension icon" class="extension-icon">
+        <div class="extension-name">AI Suggested Replies For WhatsApp</div>
       </div>
     </nav>
     <nav id="sidebar" class="sidebar" aria-label="Main">


### PR DESCRIPTION
## Summary
- Fix vertical alignment between sidebar and main options content by stretching panes to full height and removing extra padding.
- Replace avatar with extension branding in icon bar, showing extension icon and name.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894461502e48320810a633dd9d13556