### PR TITLE
feat: adjust settings layout

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -368,10 +368,28 @@ input.error {
   font-family: monospace;
 }
 
+.api-key-input {
+  min-width: 420px;
+  width: 100%;
+  max-width: 600px;
+}
+
+.system-instructions-textarea {
+  min-width: 420px;
+  width: 100%;
+  max-width: 600px;
+  min-height: 160px;
+}
+
 #show-advanced-improve {
   width: 20px;
   height: 20px;
   margin-right: 8px;
+}
+
+.improve-section label {
+  display: flex;
+  align-items: center;
 }
 
 #save-button {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -75,7 +75,7 @@
             </div>
             <label for="api-key">API Key</label>
             <div class="input-group">
-              <input type="password" id="api-key" name="api-key" class="wide-input monospace" aria-describedby="api-key-feedback">
+              <input type="password" id="api-key" name="api-key" class="wide-input monospace api-key-input" aria-describedby="api-key-feedback">
               <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">
                 <img src="../icons/Eye Icon - Show Password.svg" alt="">
               </button>
@@ -85,7 +85,7 @@
 
           <fieldset id="system-instructions">
             <legend>System Instructions</legend>
-            <textarea id="prompt-template" name="prompt-template" class="wide-input" rows="12"></textarea>
+            <textarea id="prompt-template" name="prompt-template" class="wide-input system-instructions-textarea" rows="12"></textarea>
           </fieldset>
 
           <div id="improve-section" class="improve-section">


### PR DESCRIPTION
## Summary
- expand API key and system instruction fields for better usability
- vertically center advanced options checkbox and label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68945007d12083209d1c2d92590550e2