### PR TITLE
style: align AI buttons with WhatsApp filter look

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -23,20 +23,16 @@ const style = document.createElement('style');
 style.textContent = `
 /* Theme variables */
 :root {
-  --gpt-btn-bg: #007bff;
-  --gpt-btn-text: #fff;
-  --gpt-btn-spinner-border: rgba(255, 255, 255, 0.3);
-  --gpt-btn-spinner-top: #fff;
+  --gpt-btn-spinner-border: rgba(0, 0, 0, 0.1);
+  --gpt-btn-spinner-top: #54656F;
   --message-spinner-border: rgba(0, 0, 0, 0.1);
   --message-spinner-top: #54656F;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --gpt-btn-bg: #0056b3;
-    --gpt-btn-text: #fff;
-    --gpt-btn-spinner-border: rgba(255, 255, 255, 0.3);
-    --gpt-btn-spinner-top: #fff;
+    --gpt-btn-spinner-border: rgba(255, 255, 255, 0.1);
+    --gpt-btn-spinner-top: #d1d7db;
     --message-spinner-border: rgba(255, 255, 255, 0.1);
     --message-spinner-top: #d1d7db;
   }
@@ -51,10 +47,6 @@ style.textContent = `
   font-size: 16px;
   font-weight: bold;
   text-decoration: none;
-  color: var(--gpt-btn-text);
-  background-color: var(--gpt-btn-bg);
-  border: none;
-  border-radius: 4px;
   cursor: pointer;
   white-space: nowrap;
   flex-shrink: 0;
@@ -90,6 +82,21 @@ style.textContent = `
 .gptbtn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.wa-reply-btn {
+  border-radius: 42px !important;
+  background: #fff !important;
+  color: #111;
+  border: 1px solid #ececec;
+  box-shadow: none;
+  transition: background 0.2s, color 0.2s;
+}
+
+.wa-reply-btn:hover,
+.wa-reply-btn:focus {
+  background: #e7f6ee !important;
+  color: #075e54;
 }
 
 .gpt-message {

--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -6,40 +6,7 @@ function createGptButton(label = 'Suggest Response', id) {
   gptButton.type = 'button';
   gptButton.id = id || '';
   gptButton.innerHTML = `<span class="gptbtn-text">${label}</span><span class="spinner"></span>`;
-  gptButton.className = 'gptbtn';
-
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const baseBg = prefersDark ? '#005C4B' : '#D9FDD3';
-  const hoverBg = prefersDark ? '#1F7767' : '#BCE5A7';
-  const textColor = prefersDark ? '#E9EDEF' : '#54656F';
-
-  gptButton.style.backgroundColor = baseBg;
-  gptButton.style.color = textColor;
-  gptButton.style.padding = '10px';
-  gptButton.style.border = 'none';
-  gptButton.style.borderRadius = '5px';
-
-  // Add hover effect
-  gptButton.style.transition = 'background-color 0.3s ease';
-
-  gptButton.addEventListener('mouseover', () => {
-    gptButton.style.backgroundColor = hoverBg;
-  });
-
-  gptButton.addEventListener('mouseout', () => {
-    gptButton.style.backgroundColor = baseBg;
-  });
-
-  // Add pressed effect
-  gptButton.style.boxShadow = 'inset 0 0 5px rgba(0, 0, 0, 0.2)';
-
-  gptButton.addEventListener('mousedown', () => {
-    gptButton.style.boxShadow = 'inset 0 0 10px rgba(0, 0, 0, 0.4)';
-  });
-
-  gptButton.addEventListener('mouseup', () => {
-    gptButton.style.boxShadow = 'inset 0 0 5px rgba(0, 0, 0, 0.2)';
-  });
+  gptButton.className = 'gptbtn wa-reply-btn';
   return {
     gptButton,
     setBusy(value) {


### PR DESCRIPTION
## Summary
- restyle AI action buttons to match WhatsApp Web filter pills
- remove inline styling in `createGptButton` and use new CSS class

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689452e56f788320883665360591874b