### PR TITLE
chore: update extension icons

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,10 +4,10 @@
   "version": "0.0.7",
   "description": "AI suggested replies for WhatsApp™ web",
   "icons": {
-    "16": "icons/Ext-Icon-1.png",
-    "32": "icons/Ext-Icon-1.png",
-    "48": "icons/Ext-Icon-1.png",
-    "128": "icons/Ext-Icon-1.png"
+    "16": "icons/Smart Replies for WhatsApp - PNG 16x16.png",
+    "32": "icons/Smart Replies for WhatsApp - PNG 32x32.png",
+    "48": "icons/Smart Replies for WhatsApp - PNG 48x48.png",
+    "128": "icons/Smart Replies for WhatsApp - PNG 128x128.png"
   },
   "background": {
     "service_worker": "background.js",
@@ -15,7 +15,12 @@
   },
   "action": {
     "default_title": "AI Suggested Replies For WhatsApp",
-    "default_icon": "icons/Ext-Icon-1.png",
+    "default_icon": {
+      "16": "icons/Smart Replies for WhatsApp - PNG 16x16.png",
+      "32": "icons/Smart Replies for WhatsApp - PNG 32x32.png",
+      "48": "icons/Smart Replies for WhatsApp - PNG 48x48.png",
+      "128": "icons/Smart Replies for WhatsApp - PNG 128x128.png"
+    },
     "default_popup": "options/options.html"
   },
   "options_page": "options/options.html",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -18,11 +18,11 @@
         <li><button class="icon-item" data-tab="bugs" aria-label="Bug / Feature Request"><img src="../icons/Bug.svg" alt="Bug icon"></button></li>
         <li><button class="icon-item" data-tab="help" aria-label="Help"><img src="../icons/Help.svg" alt="Help icon"></button></li>
       </ul>
-      <div class="extension-branding">
-        <img src="../icons/icon_48.png" alt="Extension icon" class="extension-icon">
+        <div class="extension-branding">
+        <img src="../icons/Smart Replies for WhatsApp - SVG Logo.svg" alt="Extension icon" class="extension-icon">
         <div class="extension-name">AI Suggested Replies For WhatsApp</div>
-      </div>
-    </nav>
+        </div>
+      </nav>
     <nav id="sidebar" class="sidebar" aria-label="Main">
       <ul>
         <li><button class="nav-item active" data-tab="settings" aria-current="page">


### PR DESCRIPTION
## Summary
- use new Smart Replies logo for options page branding
- switch manifest icons to new PNG sizes and set toolbar icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68946cd04f44832086790ff7299b8740