### PR TITLE
Add popup menu with enable toggle

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1,6 +1,8 @@
-(() => {
+(async () => {
   // contentScript.js - version 2025-08-05T00:44:54Z
   'use strict';
+  const {extensionEnabled = true} = await chrome.storage.local.get({extensionEnabled: true});
+  if (!extensionEnabled) return;
   if (window.__gptContentScriptLoaded) return;
   window.__gptContentScriptLoaded = true;
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,7 @@
       "48": "icons/Smart Replies for WhatsApp - PNG 48x48.png",
       "128": "icons/Smart Replies for WhatsApp - PNG 128x128.png"
     },
-    "default_popup": "options/options.html"
+    "default_popup": "popup.html"
   },
   "options_page": "options/options.html",
     "permissions": [

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -134,7 +134,8 @@
       </section>
       <section id="bugs" class="tab-content" role="tabpanel">
         <h1 class="page-title">Bug / Feature Request</h1>
-        <p>Found an issue or have an idea? Visit our project page on <a href="https://github.com/" target="_blank" rel="noopener">GitHub</a> to open an issue.</p>
+        <p>Found an issue or have an idea? Visit our GitHub issues page to report bugs or request features.</p>
+        <p><a href="https://github.com/PalWorks/AI-Suggested-Replies-For-WhatsApp/issues" target="_blank" rel="noopener">Open GitHub Issues</a></p>
       </section>
       <section id="help" class="tab-content" role="tabpanel">
         <h1 class="page-title">Help</h1>

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,0 +1,25 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  background: #fff;
+  min-width: 160px;
+}
+
+.menu {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 0;
+}
+
+.menu-item {
+  background: transparent;
+  border: none;
+  text-align: left;
+  padding: 8px 16px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.menu-item:hover {
+  background: #e5e5e5;
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="popup.css">
+  <title>AI Suggested Replies Menu</title>
+</head>
+<body>
+  <div class="menu">
+    <button id="open-settings" class="menu-item">Open Settings</button>
+    <button id="toggle-extension" class="menu-item"></button>
+    <button id="submit-bug" class="menu-item">Submit Bug / Feature Request</button>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const settingsBtn = document.getElementById('open-settings');
+  const toggleBtn = document.getElementById('toggle-extension');
+  const bugBtn = document.getElementById('submit-bug');
+
+  settingsBtn.addEventListener('click', () => {
+    chrome.runtime.openOptionsPage();
+    window.close();
+  });
+
+  bugBtn.addEventListener('click', () => {
+    chrome.tabs.create({url: 'https://github.com/PalWorks/AI-Suggested-Replies-For-WhatsApp/issues'});
+    window.close();
+  });
+
+  chrome.storage.local.get({extensionEnabled: true}, ({extensionEnabled}) => {
+    toggleBtn.textContent = extensionEnabled ? 'Turn Off' : 'Turn On';
+  });
+
+  toggleBtn.addEventListener('click', () => {
+    chrome.storage.local.get({extensionEnabled: true}, ({extensionEnabled}) => {
+      const newState = !extensionEnabled;
+      chrome.storage.local.set({extensionEnabled: newState}, () => {
+        toggleBtn.textContent = newState ? 'Turn Off' : 'Turn On';
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add minimalist extension popup with settings shortcut, enable/disable toggle and feedback link
- support enabling/disabling extension via storage and background checks
- link GitHub issues page from options page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689471f3c67883209cf53e3dc3a5c215