### PR TITLE
feat: replace suggestion copy icon

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -42,7 +42,7 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": ["utils.js", "icons/*.png", "icons/*.svg"],
+      "resources": ["utils.js", "icons/*.png", "icons/*.svg", "icons/Box-arrow-in-up-left.svg"],
       "matches": ["https://web.whatsapp.com/*"]
     }
   ]

--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -53,9 +53,20 @@ function creatCopyButton(newFooter, newButtonContainer) {
   const {
     svg: svgElement,
     buttonElement: copyButton
-  } = createButtonEmpty('Copy chat suggestion');
-  svgElement.innerHTML = '<path d="M3,13c0-2.45,1.76-4.47,4.08-4.91L5.59,9.59L7,11l4-4.01L7,3L5.59,4.41l1.58,1.58l0,0.06C3.7,6.46,1,9.42,1,13 c0,3.87,3.13,7,7,7h3v-2H8C5.24,18,3,15.76,3,13z"/><path d="M13,13v7h9v-7H13z M20,18h-5v-3h5V18z"/><rect height="7" width="9" x="13" y="4"/>\n';
-  svgElement.setAttribute('fill', 'currentColor');
+  } = createButtonEmpty('Insert suggestion into reply box');
+  fetch(chrome.runtime.getURL('icons/Box-arrow-in-up-left.svg'))
+    .then(r => r.text())
+    .then(svg => {
+      const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+      const paths = doc.querySelectorAll('path');
+      svgElement.setAttribute('viewBox', '0 0 16 16');
+      svgElement.setAttribute('width', '20');
+      svgElement.setAttribute('height', '20');
+      paths.forEach(path => {
+        path.setAttribute('fill', 'currentColor');
+        svgElement.appendChild(path);
+      });
+    });
   const theme = window.matchMedia('(prefers-color-scheme: dark)');
   const innerBtn = copyButton.querySelector('button');
   function applyIconColor() {


### PR DESCRIPTION
## Summary
- swap old copy suggestion icon for `Box-arrow-in-up-left.svg`
- expose new icon in manifest web accessible resources

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68948d3a44a48320b333a7ae5550cbec