### PR TITLE
feat: add timeout to LLM fetch

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,5 @@
 // background.js - version 2025-08-05T00:44:54Z
-import {b64ToBuf, fetchWithRetry, showToast, getDefaultModel} from './utils.js';
+import {b64ToBuf, fetchWithRetry, showToast, getDefaultModel, fetchWithTimeout} from './utils.js';
 import {logToGitHub} from './logger.js';
 
 const CONTENT_SCRIPTS = ['parser.js', 'uiStuff.js', 'improveDialog.js', 'contentScript.js'];
@@ -116,7 +116,7 @@ async function sendLLM(prompt, tabId) {
       method: 'POST',
       headers,
       body
-    }, 3, [500, 1000, 2000], fetch, logToGitHub);
+    }, 3, [500, 1000, 2000], fetchWithTimeout, logToGitHub);
 
     let usage;
 
@@ -184,9 +184,10 @@ async function sendLLM(prompt, tabId) {
       responseTime: endTime - startTime
     });
   } catch (err) {
-    chrome.tabs.sendMessage(tabId, {type: 'error', data: err.message});
-    showToast(err.message);
-    logToGitHub(`LLM request failed: ${err.message}\n${err.stack || ''}`).catch(() => {});
+    const msg = err.name === 'AbortError' ? 'Request timed out' : err.message;
+    chrome.tabs.sendMessage(tabId, {type: 'error', data: msg, error: msg});
+    showToast(msg);
+    logToGitHub(`LLM request failed: ${msg}\n${err.stack || ''}`).catch(() => {});
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,6 +33,16 @@ export function b64ToBuf(b64) {
   return Uint8Array.from(Buffer.from(b64, 'base64'));
 }
 
+export async function fetchWithTimeout(resource, options = {}, timeout = 20000) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetch(resource, {...options, signal: controller.signal});
+  } finally {
+    clearTimeout(id);
+  }
+}
+
 export async function fetchWithRetry(
   url,
   options,


### PR DESCRIPTION
## Summary
- support abortable fetches with new `fetchWithTimeout` helper
- use request timeout for LLM API calls and notify UI on timeout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68949bdeec1c832085b2800369a4b9d2