### PR TITLE
feat: add timeout to LLM fetch

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -33,6 +33,16 @@ export function b64ToBuf(b64) {
   return Uint8Array.from(Buffer.from(b64, 'base64'));
 }
 
+export async function fetchWithTimeout(resource, options = {}, timeout = 20000) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetch(resource, {...options, signal: controller.signal});
+  } finally {
+    clearTimeout(id);
+  }
+}
+
 export async function fetchWithRetry(
   url,
   options,


### PR DESCRIPTION
## Summary
- support abortable fetches with new `fetchWithTimeout` helper
- use request timeout for LLM API calls and notify UI on timeout
- add content-script timeout to hide loader and toast when no response
- standardize LLM error propagation to content script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68949bdeec1c832085b2800369a4b9d2