### PR TITLE
Improve messaging error handling

### DIFF
--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -41,10 +41,11 @@ function createButtonEmpty(title) {
 function createAndAddOptionsButton(newButtonContainer) {
     const optionsButton = createButton('m9.25 22-.4-3.2q-.325-.125-.612-.3-.288-.175-.563-.375L4.7 19.375l-2.75-4.75 2.575-1.95Q4.5 12.5 4.5 12.337v-.675q0-.162.025-.337L1.95 9.375l2.75-4.75 2.975 1.25q.275-.2.575-.375.3-.175.6-.3l.4-3.2h5.5l.4 3.2q.325.125.613.3.287.175.562.375l2.975-1.25 2.75 4.75-2.575 1.95q.025.175.025.337v.675q0 .163-.05.338l2.575 1.95-2.75 4.75-2.95-1.25q-.275.2-.575.375-.3.175-.6.3l-.4 3.2Zm2.8-6.5q1.45 0 2.475-1.025Q15.55 13.45 15.55 12q0-1.45-1.025-2.475Q13.5 8.5 12.05 8.5q-1.475 0-2.488 1.025Q8.55 10.55 8.55 12q0 1.45 1.012 2.475Q10.575 15.5 12.05 15.5Zm0-2q-.625 0-1.062-.438-.438-.437-.438-1.062t.438-1.062q.437-.438 1.062-.438t1.063.438q.437.437.437 1.062t-.437 1.062q-.438.438-1.063.438ZM12 12Zm-1 8h1.975l.35-2.65q.775-.2 1.438-.588.662-.387 1.212-.937l2.475 1.025.975-1.7-2.15-1.625q.125-.35.175-.738.05-.387.05-.787t-.05-.788q-.05-.387-.175-.737l2.15-1.625-.975-1.7-2.475 1.05q-.55-.575-1.212-.963-.663-.387-1.438-.587L13 4h-1.975l-.35 2.65q-.775.2-1.437.587-.663.388-1.213.938L5.55 7.15l-.975 1.7 2.15 1.6q-.125.375-.175.75-.05.375-.05.8 0 .4.05.775t.175.75l-2.15 1.625.975 1.7 2.475-1.05q.55.575 1.213.962.662.388 1.437.588Z', 'Options');
     optionsButton.addEventListener('click', () => {
-        try {
-            chrome.runtime.sendMessage({action: 'openOptionsPage'});
-        } catch (e) {// ignore, sometimes happens when reloading the extension, but don't want to see it pop up in the console
-        }
+        chrome.runtime.sendMessage({action: 'openOptionsPage'}, response => {
+            if (chrome.runtime.lastError || !response) {
+                console.error('Failed to open options page', chrome.runtime.lastError);
+            }
+        });
     });
     newButtonContainer.appendChild(optionsButton);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -105,20 +105,28 @@ export function showToast(message) {
   } else if (typeof chrome !== 'undefined' && chrome.tabs && chrome.tabs.query) {
     try {
       chrome.tabs.query({active: true, currentWindow: true}, tabs => {
-        if (tabs[0] && tabs[0].id !== undefined) {
-          chrome.tabs.sendMessage(tabs[0].id, {type: 'showToast', message});
-        }
-      });
-    } catch (e) {
-      // ignore messaging errors
+          if (tabs[0] && tabs[0].id !== undefined) {
+            chrome.tabs.sendMessage(tabs[0].id, {type: 'showToast', message}, () => {
+              if (chrome.runtime.lastError) {
+                console.error('Failed to send toast to tab', chrome.runtime.lastError);
+              }
+            });
+          }
+        });
+      } catch (e) {
+        // ignore messaging errors
+      }
+    } else if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.sendMessage) {
+      try {
+        chrome.runtime.sendMessage({type: 'showToast', message}, () => {
+          if (chrome.runtime.lastError) {
+            console.error('Failed to send toast message', chrome.runtime.lastError);
+          }
+        });
+      } catch (e) {
+        // ignore runtime errors
+      }
+    } else {
+      console.log(message);
     }
-  } else if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.sendMessage) {
-    try {
-      chrome.runtime.sendMessage({type: 'showToast', message});
-    } catch (e) {
-      // ignore runtime errors
-    }
-  } else {
-    console.log(message);
   }
-}


### PR DESCRIPTION
## Summary
- Add `safeSendTabMessage` wrapper in background to send fallback errors when messaging fails
- Return acknowledgements for runtime messages and handle sendMessage failures in content script
- Log messaging failures in UI button and toast helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894b58cbac083208a8e976b4a185d64