### PR TITLE
feat: improve dark mode UI and default prompt

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -23,6 +23,8 @@
   --wa-accent: var(--accent);
   --input-border-light: #d1d7db;
   --input-border-dark: #2a3942;
+  --icon-filter-light: none;
+  --icon-filter-dark: invert(1) brightness(1.2);
 }
 
 body {
@@ -76,6 +78,7 @@ body {
 .icon-item img {
   width: 24px;
   height: 24px;
+  filter: var(--icon-filter-light);
 }
 
 .icon-item.active {
@@ -117,6 +120,10 @@ body {
   }
   .icon-item.active {
     background: var(--divider-dark);
+  }
+  .icon-item img,
+  .eye-icon img {
+    filter: var(--icon-filter-dark);
   }
 }
 
@@ -321,6 +328,7 @@ button {
 .eye-icon img {
   width: 24px;
   height: 24px;
+  filter: var(--icon-filter-light);
 }
 
 .feedback {

--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -22,32 +22,67 @@ function createGptButton(label = 'Suggest Response', id) {
   };
 }
 
-function createButton(pathVariable, title) {
-    const buttonElement = document.createElement("button");
-    buttonElement.innerHTML = "<button class=\"svlsagor\"><span><svg viewBox=\"0 0 24 24\" height=\"24\" width=\"24\" preserveAspectRatio=\"xMidYMid meet\"><path fill=\"green\"></path></svg></span></button>";
-    buttonElement.querySelector('path').setAttribute('d', pathVariable)
-    buttonElement.setAttribute('title', title)
-    return buttonElement;
-}
-
 function createButtonEmpty(title) {
     const buttonElement = document.createElement("button");
-    buttonElement.innerHTML = "<button class=\"svlsagor\"><span><svg viewBox=\"0 0 24 24\" height=\"24\" width=\"24\" preserveAspectRatio=\"xMidYMid meet\"></svg></span></button>";
-    buttonElement.setAttribute('title', title)
-    const svg = buttonElement.querySelector('svg')
+    buttonElement.innerHTML = "<button class=\"svlsagor\"><span><svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" preserveAspectRatio=\"xMidYMid meet\"></svg></span></button>";
+    buttonElement.setAttribute('title', title);
+    const svg = buttonElement.querySelector('svg');
+    const inner = buttonElement.querySelector('button');
+    if (inner) {
+      inner.style.display = 'flex';
+      inner.style.alignItems = 'center';
+      inner.style.justifyContent = 'center';
+      inner.style.width = '24px';
+      inner.style.height = '24px';
+      inner.style.padding = '0';
+      inner.style.border = 'none';
+      inner.style.background = 'transparent';
+    }
     return {svg, buttonElement};
 }
 
 function createAndAddOptionsButton(newButtonContainer) {
-    const optionsButton = createButton('m9.25 22-.4-3.2q-.325-.125-.612-.3-.288-.175-.563-.375L4.7 19.375l-2.75-4.75 2.575-1.95Q4.5 12.5 4.5 12.337v-.675q0-.162.025-.337L1.95 9.375l2.75-4.75 2.975 1.25q.275-.2.575-.375.3-.175.6-.3l.4-3.2h5.5l.4 3.2q.325.125.613.3.287.175.562.375l2.975-1.25 2.75 4.75-2.575 1.95q.025.175.025.337v.675q0 .163-.05.338l2.575 1.95-2.75 4.75-2.95-1.25q-.275.2-.575.375-.3.175-.6.3l-.4 3.2Zm2.8-6.5q1.45 0 2.475-1.025Q15.55 13.45 15.55 12q0-1.45-1.025-2.475Q13.5 8.5 12.05 8.5q-1.475 0-2.488 1.025Q8.55 10.55 8.55 12q0 1.45 1.012 2.475Q10.575 15.5 12.05 15.5Zm0-2q-.625 0-1.062-.438-.438-.437-.438-1.062t.438-1.062q.437-.438 1.062-.438t1.063.438q.437.437.437 1.062t-.437 1.062q-.438.438-1.063.438ZM12 12Zm-1 8h1.975l.35-2.65q.775-.2 1.438-.588.662-.387 1.212-.937l2.475 1.025.975-1.7-2.15-1.625q.125-.35.175-.738.05-.387.05-.787t-.05-.788q-.05-.387-.175-.737l2.15-1.625-.975-1.7-2.475 1.05q-.55-.575-1.212-.963-.663-.387-1.438-.587L13 4h-1.975l-.35 2.65q-.775.2-1.437.587-.663.388-1.213.938L5.55 7.15l-.975 1.7 2.15 1.6q-.125.375-.175.75-.05.375-.05.8 0 .4.05.775t.175.75l-2.15 1.625.975 1.7 2.475-1.05q.55.575 1.213.962.662.388 1.437.588Z', 'Options');
-    optionsButton.addEventListener('click', () => {
-        chrome.runtime.sendMessage({action: 'openOptionsPage'}, response => {
-            if (chrome.runtime.lastError || !response) {
-                console.error('Failed to open options page', chrome.runtime.lastError);
-            }
-        });
+  const {
+    svg: svgElement,
+    buttonElement: optionsButton
+  } = createButtonEmpty('Options');
+  fetch(chrome.runtime.getURL('icons/Settings Gear.svg'))
+    .then(r => r.text())
+    .then(svg => {
+      const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+      const circle = doc.querySelector('circle');
+      const path = doc.querySelector('path');
+      svgElement.setAttribute('viewBox', '0 0 24 24');
+      if (circle) {
+        circle.setAttribute('stroke', 'currentColor');
+        circle.setAttribute('stroke-width', '1.5');
+        svgElement.appendChild(circle);
+      }
+      if (path) {
+        path.setAttribute('stroke', 'currentColor');
+        path.setAttribute('stroke-width', '1.5');
+        path.setAttribute('stroke-linecap', 'round');
+        path.setAttribute('stroke-linejoin', 'round');
+        svgElement.appendChild(path);
+      }
     });
-    newButtonContainer.appendChild(optionsButton);
+  const theme = window.matchMedia('(prefers-color-scheme: dark)');
+  const innerBtn = optionsButton.querySelector('button');
+  function applyIconColor() {
+    const color = theme.matches ? 'rgba(233, 237, 239, 0.8)' : 'rgba(84, 101, 111, 0.8)';
+    optionsButton.style.color = color;
+    if (innerBtn) innerBtn.style.color = color;
+  }
+  applyIconColor();
+  theme.addEventListener('change', applyIconColor);
+  optionsButton.addEventListener('click', () => {
+    chrome.runtime.sendMessage({action: 'openOptionsPage'}, response => {
+      if (chrome.runtime.lastError || !response) {
+        console.error('Failed to open options page', chrome.runtime.lastError);
+      }
+    });
+  });
+  newButtonContainer.appendChild(optionsButton);
 }
 
 function creatCopyButton(newFooter, newButtonContainer) {
@@ -59,11 +94,11 @@ function creatCopyButton(newFooter, newButtonContainer) {
     .then(r => r.text())
     .then(svg => {
       const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
-      const paths = doc.querySelectorAll('path');
-      svgElement.setAttribute('viewBox', '0 0 16 16');
-      svgElement.setAttribute('width', '20');
-      svgElement.setAttribute('height', '20');
-      paths.forEach(path => {
+      const svgNode = doc.querySelector('svg');
+      if (!svgNode) return;
+      const viewBox = svgNode.getAttribute('viewBox') || '0 0 16 16';
+      svgElement.setAttribute('viewBox', viewBox);
+      svgNode.querySelectorAll('path').forEach(path => {
         path.setAttribute('fill', 'currentColor');
         svgElement.appendChild(path);
       });
@@ -71,14 +106,12 @@ function creatCopyButton(newFooter, newButtonContainer) {
   const theme = window.matchMedia('(prefers-color-scheme: dark)');
   const innerBtn = copyButton.querySelector('button');
   function applyIconColor() {
-    const color = theme.matches ? '#E9EDEF' : '#54656F';
+    const color = theme.matches ? 'rgba(233, 237, 239, 0.8)' : 'rgba(84, 101, 111, 0.8)';
     copyButton.style.color = color;
     if (innerBtn) innerBtn.style.color = color;
   }
   applyIconColor();
   theme.addEventListener('change', applyIconColor);
-  newFooter.querySelectorAll('.selectable-text.copyable-text')[0];
-  copyButton.style.marginRight = '10px';
   newButtonContainer.appendChild(copyButton);
   return copyButton;
 }
@@ -92,17 +125,19 @@ function createDeleteButton(newFooter, newButtonContainer) {
     .then(r => r.text())
     .then(svg => {
       const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
-      const path = doc.querySelector('path');
-      if (path) {
+      const svgNode = doc.querySelector('svg');
+      if (!svgNode) return;
+      const viewBox = svgNode.getAttribute('viewBox') || '0 0 20 20';
+      svgElement.setAttribute('viewBox', viewBox);
+      svgNode.querySelectorAll('path').forEach(path => {
         path.setAttribute('fill', 'currentColor');
-        svgElement.setAttribute('viewBox', '0 0 20 20');
         svgElement.appendChild(path);
-      }
+      });
     });
   const theme = window.matchMedia('(prefers-color-scheme: dark)');
   const innerBtn = deleteButton.querySelector('button');
   function applyIconColor() {
-    const color = theme.matches ? '#E9EDEF' : '#54656F';
+    const color = theme.matches ? 'rgba(233, 237, 239, 0.8)' : 'rgba(84, 101, 111, 0.8)';
     deleteButton.style.color = color;
     if (innerBtn) innerBtn.style.color = color;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,17 +3,27 @@
 
 export const encoder = new TextEncoder();
 
-export const DEFAULT_PROMPT = `You are an AI-powered reply assistant integrated into a Chrome extension for WhatsApp Web.
-You will receive the last 10 user and contact messages in a conversation.
-Your job is to generate one or more short, contextually accurate, and natural-sounding reply suggestions.
-Follow these rules:
-- Maintain the conversation flow and tone from the recent messages.
-- Be concise (1–2 sentences per reply).
-- Avoid repeating exact phrases from earlier messages unless necessary for politeness or clarity.
-- Do not ask redundant questions already answered in the conversation.
-- Maintain grammatical correctness and natural language style.
-- Keep replies friendly and human-like without sounding overly formal unless the conversation tone requires it.
-- Do not add extra explanation, metadata, or reasoning—only output the suggested reply text(s).`;
+export const DEFAULT_PROMPT = `You are an AI reply assistant for WhatsApp Web, integrated via a Chrome extension.
+You receive the last 10 messages in a chat (from both the user and their contact(s)). Each message may include the sender’s name or phone number, especially in group chats.
+
+Your task: Generate one concise, contextually relevant, and natural-sounding reply suggestion for the user to send.
+
+Guidelines:
+- Match the tone, formality, and style of the recent conversation (including use of emojis or formal language as appropriate).
+- Adapt to the likely relationship between participants (e.g., friend, colleague, family, customer).
+- If the conversation is in a language other than English, reply in that language.
+- Reply directly to questions; react naturally to statements or updates.
+- In group chats:
+    - If the reply is intended for a specific participant (based on recent context or mentions), begin your suggestion with “@Name” or “@PhoneNumber” to clearly direct the reply.
+    - Otherwise, keep replies general.
+- Be brief (1–2 sentences). Avoid filler words or over-explanation.
+- Avoid repeating exact phrases from recent messages unless necessary for clarity or politeness.
+- Never ask questions that have already been answered in the conversation.
+- Handle sensitive or emotional contexts (apologies, condolences, congratulations, urgent requests) with appropriate tact and empathy.
+- Do not add any extra explanations, reasoning, or metadata—only output the suggested reply text.
+
+Output format:
+- Only the reply suggestion, with no bullet points, numbering, or explanation.`;
 
 export function strToBuf(str) {
   return new TextEncoder().encode(str);


### PR DESCRIPTION
## Summary
- update default system prompt for reply generation
- unify overlay action icons with theme-aware styling
- enhance settings page icons and inputs for dark mode
- restore original copy and delete icon shapes with theme-aware fill colors

## Testing
- `npm test` *(fails: Cannot find module '/workspace/AI-Suggested-Replies-For-WhatsApp/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_6894c2a40d4c8320bfb452f602cb720a