### PR TITLE
Use softer background for AI buttons in dark mode

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -38,6 +38,14 @@ style.textContent = `
     --message-spinner-border: rgba(255, 255, 255, 0.1);
     --message-spinner-top: #d1d7db;
   }
+
+  .wa-reply-btn {
+    background: #fafafa !important;
+  }
+
+  .wa-reply-btn:disabled {
+    background: #fafafa !important;
+  }
 }
 
 .gptbtn {


### PR DESCRIPTION
## Summary
- Use #fafafa background for "Suggest Response" and "Improve my response" buttons when WhatsApp Web is in dark mode
- Apply the color for both normal and disabled button states

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894cc4f239083208a37139a5ffa9c5a