### PR TITLE
Add summary bar for LLM call history

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -279,6 +279,18 @@ button {
   margin-bottom: 16px;
 }
 
+#llm-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 8px;
+  font-size: 14px;
+}
+
+#llm-summary span {
+  white-space: nowrap;
+}
+
 .history-table-wrapper {
   overflow: auto;
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -103,6 +103,7 @@
         <div class="history-header">
           <button id="download-csv" class="primary-button">Download CSV</button>
         </div>
+        <div id="llm-summary"></div>
         <div class="history-table-wrapper">
           <table id="history-table">
             <thead>


### PR DESCRIPTION
## Summary
- Add summary container above call history table
- Compute and render LLM call stats for last 7 days or 100 entries
- Style summary bar for responsive display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895a23adacc8320b13b27908efc02ad