### PR TITLE
Refactor history reload workflow

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -2,11 +2,18 @@ import {strToBuf, bufToB64, b64ToBuf, DEFAULT_PROMPT, getDefaultModel} from '../
 
 document.addEventListener('DOMContentLoaded', () => {
   restoreOptions();
-  renderHistory();
+  reloadLogsAndSummary();
   setupNavigation();
 });
 document.getElementById('options-form').addEventListener('submit', saveOptions);
 document.getElementById('download-csv').addEventListener('click', downloadCsv);
+const clearLogsBtn = document.getElementById('clear-logs');
+if (clearLogsBtn) {
+  clearLogsBtn.addEventListener('click', async () => {
+    await chrome.storage.local.remove('history');
+    reloadLogsAndSummary();
+  });
+}
 
 const apiChoiceSelect = document.getElementById('api-choice');
 const apiKeyInput = document.getElementById('api-key');
@@ -225,9 +232,7 @@ function renderSummary(summary) {
     </div>`;
 }
 
-async function renderHistory() {
-  const {history = []} = await chrome.storage.local.get({history: []});
-  renderSummary(computeSummary(history));
+function renderLlmHistoryTable(history) {
   const tbody = document.querySelector('#history-table tbody');
   tbody.innerHTML = '';
   for (const item of history) {
@@ -248,6 +253,12 @@ async function renderHistory() {
     }
     tbody.appendChild(tr);
   }
+}
+
+async function reloadLogsAndSummary() {
+  const {history = []} = await chrome.storage.local.get({history: []});
+  renderSummary(computeSummary(history));
+  renderLlmHistoryTable(history);
 }
 
 async function downloadCsv() {


### PR DESCRIPTION
## Summary
- Add `reloadLogsAndSummary` to compute summary and render history table
- Wire up Clear Logs button to remove `history` and refresh display
- Use unified history reload on page load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895ac318ee883208be3d96b58afc05f