### PR TITLE
Use new settings gear icon

### DIFF
--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -46,7 +46,7 @@ function createAndAddOptionsButton(newButtonContainer) {
     svg: svgElement,
     buttonElement: optionsButton
   } = createButtonEmpty('Options');
-  fetch(chrome.runtime.getURL('icons/Settings Gear.svg'))
+  fetch(chrome.runtime.getURL('icons/SettingsGear2.svg'))
     .then(r => r.text())
     .then(svg => {
       const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');


### PR DESCRIPTION
## Summary
- swap options button icon to `SettingsGear2.svg`
- ensure manifest already exposes SVG icons to WhatsApp

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895bed5b5948320a6ef8866839d5236