### PR TITLE
feat: expand history logging and context limit

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -42,6 +42,20 @@ body {
   }
 }
 
+.app-titlebar {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: var(--bg, #f7f7f7);
+  padding: 10px 16px 0;
+}
+
+.app-title {
+  margin: 0 0 6px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
 .options-container {
   display: flex;
   height: 100vh;
@@ -99,15 +113,7 @@ body {
 }
 
 .extension-name {
-  margin-top: 4px;
-  font-size: 12px;
-  color: #8696a0;
-}
-
-@media (prefers-color-scheme: dark) {
-  .extension-name {
-    color: #b1b9be;
-  }
+  display: none;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -326,7 +332,7 @@ button {
   font-size: 13px;
 }
 
-.chat-history-cell {
+.cell-scroll {
   max-height: 160px;
   overflow-y: auto;
   white-space: pre-wrap;
@@ -341,23 +347,43 @@ button {
   overflow-x: auto;
 }
 
-#history-table {
+.history-table {
   width: 100%;
   border-collapse: collapse;
 }
 
-#history-table th,
-#history-table td {
+.history-table th,
+.history-table td {
   text-align: left;
   padding: 8px;
   border-bottom: 1px solid var(--wa-divider-light);
 }
 
 @media (prefers-color-scheme: dark) {
-  #history-table th,
-  #history-table td {
+  .history-table th,
+  .history-table td {
     border-bottom-color: var(--wa-divider-dark);
   }
+}
+
+.history-table .col-ts    { width: 14rem; }
+.history-table .col-model { width: 10rem; }
+.history-table .col-input { width: 34rem; }
+.history-table .col-output{ width: 28rem; }
+.history-table .col-ptok,
+.history-table .col-ctok,
+.history-table .col-ttok  { width: 8rem; text-align: right; }
+.history-table .col-rt    { width: 10rem; text-align: right; }
+
+.history-table th:nth-child(5),
+.history-table th:nth-child(6),
+.history-table th:nth-child(7),
+.history-table th:nth-child(8),
+.history-table td:nth-child(5),
+.history-table td:nth-child(6),
+.history-table td:nth-child(7),
+.history-table td:nth-child(8) {
+  text-align: right;
 }
 
 .helper {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -6,24 +6,26 @@
   <link rel="stylesheet" href="options.css">
   <title>ChatGPT Options</title>
 </head>
-<body>
-  <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
+  <body>
+    <header class="app-titlebar" role="banner">
+      <h1 class="app-title">AI Suggested Replies for WhatsApp</h1>
+    </header>
+    <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation">☰</button>
   <div class="options-container">
     <nav class="icon-bar" aria-label="Primary">
-      <ul>
-        <li><button class="icon-item active" data-tab="settings" aria-label="Settings" aria-current="page"><img src="../icons/Settings Gear.svg" alt="Settings icon"></button></li>
-        <li><button class="icon-item" data-tab="history" aria-label="Logs / History"><img src="../icons/Logs.svg" alt="Logs icon"></button></li>
-        <li><button class="icon-item" data-tab="guide" aria-label="User Guide"><img src="../icons/User Guide.svg" alt="User guide icon"></button></li>
-        <li><button class="icon-item" data-tab="about" aria-label="About"><img src="../icons/About.svg" alt="About icon"></button></li>
-        <li><button class="icon-item" data-tab="bugs" aria-label="Bug / Feature Request"><img src="../icons/Bug.svg" alt="Bug icon"></button></li>
-        <li><button class="icon-item" data-tab="privacy" aria-label="Privacy"><img src="../icons/Help.svg" alt="Privacy icon"></button></li>
-        <li><button class="icon-item" data-tab="help" aria-label="Help"><img src="../icons/Help.svg" alt="Help icon"></button></li>
-      </ul>
-        <div class="extension-branding">
-        <img src="../icons/Smart Replies for WhatsApp - SVG Logo.svg" alt="Extension icon" class="extension-icon">
-        <div class="extension-name">AI Suggested Replies For WhatsApp</div>
-        </div>
-      </nav>
+        <ul>
+          <li><button class="icon-item active" data-tab="settings" aria-label="Settings" aria-current="page"><img src="../icons/Settings Gear.svg" alt="Settings icon"></button></li>
+          <li><button class="icon-item" data-tab="history" aria-label="Logs / History"><img src="../icons/Logs.svg" alt="Logs icon"></button></li>
+          <li><button class="icon-item" data-tab="guide" aria-label="User Guide"><img src="../icons/User Guide.svg" alt="User guide icon"></button></li>
+          <li><button class="icon-item" data-tab="about" aria-label="About"><img src="../icons/About.svg" alt="About icon"></button></li>
+          <li><button class="icon-item" data-tab="bugs" aria-label="Bug / Feature Request"><img src="../icons/Bug.svg" alt="Bug icon"></button></li>
+          <li><button class="icon-item" data-tab="privacy" aria-label="Privacy"><img src="../icons/Help.svg" alt="Privacy icon"></button></li>
+          <li><button class="icon-item" data-tab="help" aria-label="Help"><img src="../icons/Help.svg" alt="Help icon"></button></li>
+        </ul>
+          <div class="extension-branding">
+          <img src="../icons/Smart Replies for WhatsApp - SVG Logo.svg" alt="Extension icon" class="extension-icon">
+          </div>
+        </nav>
     <nav id="sidebar" class="sidebar" aria-label="Main">
       <ul>
         <li><button class="nav-item active" data-tab="settings" aria-current="page">
@@ -93,16 +95,21 @@
             <textarea id="prompt-template" name="prompt-template" class="wide-input system-instructions-textarea" rows="12"></textarea>
           </fieldset>
 
-          <div id="improve-section" class="improve-section">
-            <label for="show-advanced-improve">
-              <input type="checkbox" id="show-advanced-improve">
-              Show Advanced options for Improve-My-Response button
-            </label>
-          </div>
+            <div id="improve-section" class="improve-section">
+              <label for="show-advanced-improve">
+                <input type="checkbox" id="show-advanced-improve">
+                Show Advanced options for Improve-My-Response button
+              </label>
+            </div>
+            <div class="form-row">
+              <label for="context-message-limit">Messages to include in context</label>
+              <input id="context-message-limit" type="number" min="1" max="100" step="1" placeholder="10">
+              <small>How many recent messages to send to the LLM as context.</small>
+            </div>
 
-          <button type="submit" id="save-button" class="primary-button">Save</button>
-        </form>
-      </section>
+            <button type="submit" id="save-button" class="primary-button">Save</button>
+          </form>
+        </section>
       <section id="history" class="tab-content" role="tabpanel">
         <h1 class="page-title">Logs / History</h1>
         <div class="history-header">
@@ -110,22 +117,33 @@
           <button id="clear-logs" class="danger-button" title="Delete all locally stored logs">Clear Logs</button>
         </div>
         <div id="llm-summary" class="summary-bar"></div>
-        <div class="history-table-wrapper">
-          <table id="history-table">
-            <thead>
-              <tr>
-                <th>Timestamp</th>
-                <th>Model</th>
-                <th>Chat History</th>
-                <th>Prompt Tokens</th>
-                <th>Completion Tokens</th>
-                <th>Total Tokens</th>
-                <th>Response Time (ms)</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
-        </div>
+          <div class="history-table-wrapper">
+            <table id="history-table" class="history-table">
+              <colgroup>
+                <col class="col-ts">
+                <col class="col-model">
+                <col class="col-input">
+                <col class="col-output">
+                <col class="col-ptok">
+                <col class="col-ctok">
+                <col class="col-ttok">
+                <col class="col-rt">
+              </colgroup>
+              <thead>
+                <tr>
+                  <th>Timestamp</th>
+                  <th>Model</th>
+                  <th>Input Chat Data</th>
+                  <th>Output Response</th>
+                  <th>Prompt Tokens</th>
+                  <th>Completion Tokens</th>
+                  <th>Total Tokens</th>
+                  <th>Response Time (ms)</th>
+                </tr>
+              </thead>
+              <tbody></tbody>
+            </table>
+          </div>
       </section>
       <section id="guide" class="tab-content" role="tabpanel">
         <h1 class="page-title">User Guide</h1>

--- a/src/parser.js
+++ b/src/parser.js
@@ -81,7 +81,8 @@
 
   function parseHtml(main) {
     try {
-      const chatHistory = extractRecentMessages({limit: 10, filtered: true, root: main});
+      const limit = window.contextMessageLimit || 10;
+      const chatHistory = extractRecentMessages({limit, filtered: true, root: main});
       const lastExpression = chatHistory[chatHistory.length - 1];
       let lastIsMine = false;
       if (lastExpression && lastExpression.includes('Me:')) {


### PR DESCRIPTION
## Summary
- expose LLM input/output and usage metrics in persisted history
- let users configure how many recent messages are sent as context
- add global header and streamline options branding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895f6b3497083208c9431a2adb74267