### PR TITLE
Keep theme toggle in-place and add toast

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -178,10 +178,22 @@ body {
   border-left: 4px solid var(--accent);
   background: var(--divider);
 }
+/* Group theme button and logo at the bottom */
+.rail-bottom {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+#theme-toggle-wrapper {
+  padding-top: 10px;
+}
 
 .extension-branding {
-  margin-top: auto;
-  padding: 12px 0;
+  margin-top: 0; /* override auto */
+  padding: 0 0 12px 0;
   text-align: center;
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -22,16 +22,24 @@
           <li><button class="icon-item" data-tab="privacy" aria-label="Privacy"><img src="../icons/privacyicon.svg" alt="Privacy icon"></button></li>
           <li><button class="icon-item" data-tab="help" aria-label="Help"><img src="../icons/Help.svg" alt="Help icon"></button></li>
         </ul>
-        <!-- Theme toggle button (cycles Auto → Light → Dark) -->
-        <div id="theme-toggle-wrapper" style="margin-top:auto; padding:10px 0;">
-          <button id="theme-toggle" class="icon-item" aria-label="Theme: Auto" title="Theme: Auto" style="border-left:none">
-            <img src="../icons/DarkThemeSwitcherIcon.svg" alt="Theme toggle">
-          </button>
-        </div>
-          <div class="extension-branding">
-          <img src="../icons/Smart Replies for WhatsApp - SVG Logo.svg" alt="Extension icon" class="extension-icon">
+        <!-- Bottom rail: theme toggle + branding -->
+        <div class="rail-bottom">
+          <div id="theme-toggle-wrapper">
+            <button id="theme-toggle"
+                    class="icon-item utility"
+                    aria-label="Theme: Auto"
+                    title="Theme: Auto"
+                    style="border-left:none">
+              <img src="../icons/DarkThemeSwitcherIcon.svg" alt="Theme toggle">
+            </button>
           </div>
-        </nav>
+          <div class="extension-branding">
+            <img src="../icons/Smart Replies for WhatsApp - SVG Logo.svg"
+                 alt="Extension icon"
+                 class="extension-icon">
+          </div>
+        </div>
+      </nav>
     <nav id="sidebar" class="sidebar" aria-label="Main">
       <ul>
         <li><button class="nav-item active" data-tab="settings" aria-current="page">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -1,4 +1,4 @@
-import {strToBuf, bufToB64, b64ToBuf, DEFAULT_PROMPT, getDefaultModel} from '../utils.js';
+import {strToBuf, bufToB64, b64ToBuf, DEFAULT_PROMPT, getDefaultModel, showToast} from '../utils.js';
 
 // --- Theme management: preference-aware (auto/light/dark) ---
 let _osMediaQuery = null;
@@ -65,12 +65,18 @@ async function initThemeFromStorage() {
 
   const btn = document.getElementById('theme-toggle');
   if (btn) {
-    btn.addEventListener('click', async () => {
+    btn.addEventListener('click', async (e) => {
+      e.preventDefault();
+      e.stopPropagation(); // don’t trigger nav
+
       const { themePreference: cur = 'auto' } = await chrome.storage.sync.get({ themePreference: 'auto' });
       const next = nextTheme(cur);
       await chrome.storage.sync.set({ themePreference: next });
       applyThemeFromPreference(next);
       await syncThemeToggleUi(next);
+
+      const name = next === 'auto' ? 'Auto theme' : (next === 'dark' ? 'Dark mode' : 'Light mode');
+      try { showToast(`${name} ON`); } catch {}
     });
   }
 }
@@ -440,7 +446,7 @@ function refreshWhatsAppTabs() {
 
 function setupNavigation() {
   const navItems = document.querySelectorAll('.nav-item');
-  const iconItems = document.querySelectorAll('.icon-item');
+  const iconItems = document.querySelectorAll('.icon-item[data-tab]'); // only tabs
   const sections = document.querySelectorAll('.tab-content');
   const sidebar = document.getElementById('sidebar');
   const menuToggle = document.getElementById('menu-toggle');


### PR DESCRIPTION
## Summary
- Group theme toggle and branding in a bottom rail and avoid navigation when toggling theme.
- Show a toast when switching themes and prevent theme button from acting like a tab.
- Style bottom rail elements so button and logo stay pinned together at the bottom.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896e1caf20c83209d29b925f90b02e1