### PR TITLE
Add chat metadata and nudge behavior to prompts

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -89,11 +89,26 @@
         lastIsMine = true;
       }
       const chatHistoryShortAsString = chatHistory.join('\n\n');
-      return {chatHistoryShort: chatHistoryShortAsString, lastIsMine};
+
+      // Collect distinct non-"Me" senders
+      const participants = Array.from(
+        new Set(
+          chatHistory
+            .map(line => {
+              const m = line.match(/^([^:]+):\s/);
+              const name = m ? m[1].trim() : '';
+              return name && name !== 'Me' ? name : null;
+            })
+            .filter(Boolean)
+        )
+      );
+      const chatType = participants.length > 1 ? 'group' : 'dm';
+
+      return {chatHistoryShort: chatHistoryShortAsString, lastIsMine, chatType, participants};
     } catch (e) {
       console.error('Failed to parse chat history:', e);
       if (showToast) showToast('Failed to parse chat history');
-      return {chatHistoryShort: '', lastIsMine: false};
+      return {chatHistoryShort: '', lastIsMine: false, chatType: 'dm', participants: []};
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,12 +3,14 @@
 
 export const encoder = new TextEncoder();
 
-export const DEFAULT_PROMPT = `You are an AI reply assistant for WhatsApp Web, integrated via a Chrome extension.
-You receive the last 10 messages in a chat (from both the user and their contact(s)). Each message may include the sender’s name or phone number, especially in group chats.
+export const DEFAULT_PROMPT = `Role: You are an AI reply assistant for WhatsApp Web, integrated via a Chrome extension.
 
-Your task: Generate one concise, contextually relevant, and natural-sounding reply suggestion for the user to send.
+Context: You will receive a chat data block (the last few messages in a chat) and a chat metadata block (chat.type and participants). 
+
+Task: You write WhatsApp replies on behalf of Me (the user of this extension); reply as Me, and in group chats mention @Name when clearly replying to someone. Generate one concise, contextually relevant, and natural-sounding reply suggestion for the user to send.
 
 Guidelines:
+- Speak in first person as Me; address the other person directly.
 - Match the tone, formality, and style of the recent conversation (including use of emojis or formal language as appropriate).
 - Adapt to the likely relationship between participants (e.g., friend, colleague, family, customer).
 - If the conversation is in a language other than English, reply in that language.
@@ -21,6 +23,7 @@ Guidelines:
 - Never ask questions that have already been answered in the conversation.
 - Handle sensitive or emotional contexts (apologies, condolences, congratulations, urgent requests) with appropriate tact and empathy.
 - Do not add any extra explanations, reasoning, or metadata—only output the suggested reply text.
+- Never summarize or add meta text. Output ONLY the message text.
 
 Output format:
 - Only the reply suggestion, with no bullet points, numbering, or explanation.`;


### PR DESCRIPTION
## Summary
- Include chat participant list and chat.type in parser and conversation extraction
- Adjust prompt generation to use chat metadata and send polite nudges when last message is mine
- Update default prompt text with first-person guidelines and group mention rules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68974d5aec60832081389a9644e507ef