### PR TITLE
Add custom provider with configurable endpoint

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -122,6 +122,18 @@ async function sendLLM(prompt, tabId, inputChatData) {
       url = 'https://api.mistral.ai/v1/chat/completions';
       headers.Authorization = `Bearer ${apiKey}`;
       body = JSON.stringify({...basePayload, model: modelChoice});
+    } else if (apiChoice === 'custom') {
+      const { providerUrls = {}, authSchemes = {} } = await chrome.storage.local.get({ providerUrls: {}, authSchemes: {} });
+      let base = providerUrls.custom || '';
+      while (base.endsWith('/') ) base = base.slice(0, -1);
+      if (!base) throw new Error('Custom endpoint missing');
+
+      url = `${base}/chat/completions`;
+      const scheme = authSchemes.custom || 'bearer';
+      if (scheme === 'bearer') headers.Authorization = `Bearer ${apiKey}`;
+      else headers['x-api-key'] = apiKey;
+
+      body = JSON.stringify({ ...basePayload, model: modelChoice });
     } else {
       url = 'https://api.openai.com/v1/chat/completions';
       headers.Authorization = `Bearer ${apiKey}`;

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -86,6 +86,7 @@
                   <option value="openrouter">OpenRouter</option>
                   <option value="anthropic">Anthropic</option>
                   <option value="mistral">Mistral</option>
+                  <option value="custom">Custom (OpenAI-compatible)</option>
                 </select>
               </div>
               <div class="model-col">
@@ -102,6 +103,23 @@
               </button>
             </div>
             <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
+
+            <!-- API Endpoint (read-only for built-ins, editable for Custom) -->
+            <div class="form-row">
+              <label for="api-endpoint">API Endpoint</label>
+              <input id="api-endpoint" class="api-key-input monospace" type="text"
+                     placeholder="https://host.example.com/v1">
+              <div class="helper">Base URL of your provider (OpenAI‑compatible). For example: <code>https://localhost:11434/v1</code>.</div>
+            </div>
+
+            <!-- Auth scheme selector (enabled only for Custom) -->
+            <div class="form-row">
+              <label for="auth-scheme">Auth Header</label>
+              <select id="auth-scheme">
+                <option value="bearer">Authorization: Bearer &lt;key&gt;</option>
+                <option value="x-api-key">X-API-Key: &lt;key&gt;</option>
+              </select>
+            </div>
           </fieldset>
 
           <div class="form-row">

--- a/src/utils.js
+++ b/src/utils.js
@@ -142,3 +142,22 @@ export function showToast(message, opts = {}) {
     setTimeout(() => toast.remove(), 250);
   }, duration);
 }
+
+export function defaultBase(provider) {
+  switch (provider) {
+    case 'openrouter':
+      return 'https://openrouter.ai/api/v1';
+    case 'anthropic':
+      return 'https://api.anthropic.com/v1';
+    case 'mistral':
+      return 'https://api.mistral.ai/v1';
+    case 'openai':
+      return 'https://api.openai.com/v1';
+    default:
+      return '';
+  }
+}
+
+export function defaultAuth(provider) {
+  return provider === 'anthropic' ? 'x-api-key' : 'bearer';
+}


### PR DESCRIPTION
## Summary
- add Custom provider option with API endpoint and auth header controls
- verify keys against user-provided endpoint
- route background requests through custom endpoint and auth scheme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689775b6bf108320a7effe22acc9f72d