### PR TITLE
Fix theme selection and provider settings layout

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -100,7 +100,7 @@ body {
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme="light"]) {
     --text-primary: var(--text-primary-dark);
     --text-secondary: var(--text-secondary-dark);
     --bg-main: var(--bg-main-dark);
@@ -653,3 +653,53 @@ label {
   pointer-events: none;
 }
 .wa-toast.show { opacity: 1; }
+
+/* === Provider Settings Grid (labels left, fields right) === */
+.provider-settings {
+  display: grid;
+  grid-template-columns: 220px minmax(420px, 1fr);
+  grid-auto-rows: auto;
+  gap: 12px 18px;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.provider-settings label {
+  font-weight: 600;
+  margin: 0; /* grid provides spacing */
+}
+
+.provider-settings .input-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.provider-settings .stack {
+  display: flex;
+  flex-direction: column;
+}
+
+.provider-settings .api-key-wrap {
+  display: grid;
+  grid-template-columns: 1fr auto; /* input + eye button */
+  gap: 8px;
+  align-items: center;
+}
+
+.provider-settings .api-key-wrap input {
+  min-width: 0; /* allow grid to control width */
+}
+
+.provider-settings .helper {
+  font-size: 13px;
+  color: var(--nav-subtext);
+  margin-top: 6px;
+}
+
+/* Mobile: stack labels above fields */
+@media (max-width: 720px) {
+  .provider-settings {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -78,9 +78,12 @@
         <form id="options-form">
           <fieldset id="provider-settings">
             <legend>Provider Settings</legend>
-            <div class="provider-model-row">
-              <div class="provider-col">
-                <label for="api-choice">Provider</label>
+
+            <div class="provider-settings">
+
+              <!-- Provider -->
+              <label for="api-choice">Provider</label>
+              <div class="input-cell">
                 <select id="api-choice" name="api-choice">
                   <option value="openai">OpenAI</option>
                   <option value="openrouter">OpenRouter</option>
@@ -89,36 +92,42 @@
                   <option value="custom">Custom (OpenAI-compatible)</option>
                 </select>
               </div>
-              <div class="model-col">
-                <label for="model-name">Model Name</label>
+
+              <!-- Model Name -->
+              <label for="model-name">Model Name</label>
+              <div class="input-cell stack">
                 <input type="text" id="model-name" name="model-name" class="wide-input" placeholder="gpt-3.5-turbo">
-                <p class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</p>
+                <div class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</div>
               </div>
-            </div>
-            <label for="api-key">API Key</label>
-            <div class="input-group">
-              <input type="password" id="api-key" name="api-key" class="wide-input monospace api-key-input" aria-describedby="api-key-feedback">
-              <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">
-                <img src="../icons/Eye Icon - Show Password.svg" alt="">
-              </button>
-            </div>
-            <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
 
-            <!-- API Endpoint (read-only for built-ins, editable for Custom) -->
-            <div class="form-row">
+              <!-- API Key -->
+              <label for="api-key">API Key</label>
+              <div class="input-cell stack">
+                <div class="api-key-wrap">
+                  <input type="password" id="api-key" name="api-key" class="wide-input monospace api-key-input" aria-describedby="api-key-feedback">
+                  <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">
+                    <img src="../icons/Eye Icon - Show Password.svg" alt="">
+                  </button>
+                </div>
+                <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
+              </div>
+
+              <!-- API Endpoint -->
               <label for="api-endpoint">API Endpoint</label>
-              <input id="api-endpoint" class="api-key-input monospace" type="text"
-                     placeholder="https://host.example.com/v1">
-              <div class="helper">Base URL of your provider (OpenAI‑compatible). For example: <code>https://localhost:11434/v1</code>.</div>
-            </div>
+              <div class="input-cell stack">
+                <input id="api-endpoint" class="api-key-input monospace" type="text" placeholder="https://host.example.com/v1">
+                <div class="helper">Base URL of your provider (OpenAI‑compatible). For example: <code>https://localhost:11434/v1</code>.</div>
+              </div>
 
-            <!-- Auth scheme selector (enabled only for Custom) -->
-            <div class="form-row">
+              <!-- Auth Header -->
               <label for="auth-scheme">Auth Header</label>
-              <select id="auth-scheme">
-                <option value="bearer">Authorization: Bearer &lt;key&gt;</option>
-                <option value="x-api-key">X-API-Key: &lt;key&gt;</option>
-              </select>
+              <div class="input-cell">
+                <select id="auth-scheme">
+                  <option value="bearer">Authorization: Bearer &lt;key&gt;</option>
+                  <option value="x-api-key">X-API-Key: &lt;key&gt;</option>
+                </select>
+              </div>
+
             </div>
           </fieldset>
 


### PR DESCRIPTION
## Summary
- respect explicit light theme over OS dark setting
- reorganize provider settings into a two-column grid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68978895c814832097f3b2520decd53e