### PR TITLE
Improve provider settings layout and dark-mode icons

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -175,6 +175,16 @@ style.textContent = `
 
 /* message spinner removed; buttons now show their own loader */
 `;
+// Append cross-theme icon filter variables used by our WA icons
+style.textContent += `
+:root { --icon-filter: none; }
+/* WhatsApp toggles dark mode via body.dark */
+body.dark { --icon-filter: invert(1) brightness(1.2); }
+/* Fallback when WA hasn't set body.dark but OS prefers dark */
+@media (prefers-color-scheme: dark) {
+  body:not(.dark) { --icon-filter: invert(1) brightness(1.2); }
+}
+`;
 document.head.appendChild(style);
 
   let errorBanner;

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -703,3 +703,25 @@ label {
     grid-template-columns: 1fr;
   }
 }
+
+/* --- Provider Settings grid (labels left, fields right) --- */
+#provider-settings .provider-settings {
+  display: grid;
+  grid-template-columns: 180px minmax(420px, 1fr); /* tighter left column */
+  align-items: center;
+  gap: 12px 18px;
+  max-width: 980px;
+}
+#provider-settings .provider-settings label { margin: 0; font-weight: 600; }
+#provider-settings .provider-settings .stack { display: flex; flex-direction: column; gap: 6px; }
+#provider-settings .provider-settings .api-key-wrap {
+  display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center;
+}
+@media (max-width: 720px) {
+  #provider-settings .provider-settings { grid-template-columns: 1fr; }
+}
+
+/* Context Settings section: divider line with title below; extra spacing */
+#context-settings { border-top: 1px solid var(--divider); padding-top: 14px; margin-top: 8px; }
+#context-settings > legend { display: block; margin: 6px 0 12px; padding: 0; }
+#context-settings .form-row + .form-row { margin-top: 14px; }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -80,10 +80,9 @@
             <legend>Provider Settings</legend>
 
             <div class="provider-settings">
-
               <!-- Provider -->
               <label for="api-choice">Provider</label>
-              <div class="input-cell">
+              <div class="stack">
                 <select id="api-choice" name="api-choice">
                   <option value="openai">OpenAI</option>
                   <option value="openrouter">OpenRouter</option>
@@ -95,14 +94,14 @@
 
               <!-- Model Name -->
               <label for="model-name">Model Name</label>
-              <div class="input-cell stack">
+              <div class="stack">
                 <input type="text" id="model-name" name="model-name" class="wide-input" placeholder="gpt-3.5-turbo">
-                <div class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</div>
+                <p class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</p>
               </div>
 
               <!-- API Key -->
               <label for="api-key">API Key</label>
-              <div class="input-cell stack">
+              <div class="stack">
                 <div class="api-key-wrap">
                   <input type="password" id="api-key" name="api-key" class="wide-input monospace api-key-input" aria-describedby="api-key-feedback">
                   <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">
@@ -112,33 +111,36 @@
                 <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
               </div>
 
-              <!-- API Endpoint -->
+              <!-- API Endpoint (read-only for built-ins, editable for Custom) -->
               <label for="api-endpoint">API Endpoint</label>
-              <div class="input-cell stack">
+              <div class="stack">
                 <input id="api-endpoint" class="api-key-input monospace" type="text" placeholder="https://host.example.com/v1">
                 <div class="helper">Base URL of your provider (OpenAI‑compatible). For example: <code>https://localhost:11434/v1</code>.</div>
               </div>
 
-              <!-- Auth Header -->
-              <label for="auth-scheme">Auth Header</label>
-              <div class="input-cell">
+              <!-- Auth Header (show only for Custom; we’ll toggle via JS) -->
+              <label for="auth-scheme" id="auth-scheme-label">Auth Header</label>
+              <div class="stack" id="auth-scheme-field">
                 <select id="auth-scheme">
                   <option value="bearer">Authorization: Bearer &lt;key&gt;</option>
                   <option value="x-api-key">X-API-Key: &lt;key&gt;</option>
                 </select>
               </div>
-
             </div>
           </fieldset>
 
-          <div class="form-row">
-            <label for="context-message-limit">How many recent messages to send to the LLM as context:</label>
-            <input id="context-message-limit" type="number" min="1" max="100" step="1" placeholder="10">
-          </div>
+          <fieldset id="context-settings">
+            <legend>Context Settings</legend>
 
-          <fieldset id="system-instructions">
-            <legend>System Instructions</legend>
-            <textarea id="prompt-template" name="prompt-template" class="wide-input system-instructions-textarea" rows="12"></textarea>
+            <div class="form-row">
+              <label for="context-message-limit">How many recent messages to send to the LLM as context:</label>
+              <input id="context-message-limit" type="number" min="1" max="100" step="1" placeholder="10">
+            </div>
+
+            <div class="form-row">
+              <label for="prompt-template">System Instructions</label>
+              <textarea id="prompt-template" name="prompt-template" class="wide-input system-instructions-textarea" rows="12"></textarea>
+            </div>
           </fieldset>
 
             <div id="improve-section" class="improve-section">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -138,6 +138,13 @@ toggleBtn.addEventListener('click', () => {
   toggleBtn.setAttribute('aria-label', isText ? 'Show API key' : 'Hide API key');
 });
 
+function showAuthRow(show) {
+  const label = document.getElementById('auth-scheme-label') || document.querySelector('label[for="auth-scheme"]');
+  const field = document.getElementById('auth-scheme-field') || document.getElementById('auth-scheme')?.closest('.stack') || document.getElementById('auth-scheme')?.parentElement;
+  if (label) label.style.display = show ? '' : 'none';
+  if (field) field.style.display = show ? '' : 'none';
+}
+
 function setFeedback(message, type) {
   feedbackBox.textContent = message;
   feedbackBox.classList.remove('success', 'error');
@@ -274,11 +281,13 @@ async function loadProviderFields(provider) {
     authSchemeSelect.disabled = false;
     endpointInput.value = providerUrls.custom || '';
     authSchemeSelect.value = authSchemes.custom || 'bearer';
+    showAuthRow(true);
   } else {
     endpointInput.readOnly = true;
     authSchemeSelect.disabled = true;
     endpointInput.value = defaultBase(provider);
     authSchemeSelect.value = defaultAuth(provider);
+    showAuthRow(false);
   }
 
   if (!apiKeys[provider] || !encKeyB64) return;


### PR DESCRIPTION
## Summary
- Append cross-theme icon filter variables to content script to ensure WA icons respect light/dark modes
- Redesign Provider Settings as two-column grid and group Context Settings with divider
- Hide Auth Header controls unless Custom provider is selected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68980525e37083209b8f9b7ce8fcc913