### PR TITLE
Add References tab and polish Settings layout

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -704,24 +704,83 @@ label {
   }
 }
 
-/* --- Provider Settings grid (labels left, fields right) --- */
+/* Make fieldset legends look like the main page title */
+#provider-settings > legend,
+#context-settings > legend {
+  display: block;
+  font-size: 24px;
+  font-weight: 600;
+  margin: 8px 0 6px;
+  color: var(--text-primary);
+}
+
+/* Provider Settings — grid + equal widths */
 #provider-settings .provider-settings {
   display: grid;
-  grid-template-columns: 180px minmax(420px, 1fr); /* tighter left column */
+  grid-template-columns: 200px minmax(520px, 1fr);
   align-items: center;
   gap: 12px 18px;
   max-width: 980px;
 }
-#provider-settings .provider-settings label { margin: 0; font-weight: 600; }
-#provider-settings .provider-settings .stack { display: flex; flex-direction: column; gap: 6px; }
-#provider-settings .provider-settings .api-key-wrap {
-  display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center;
+
+/* Ensure inputs fill the right grid column uniformly */
+#provider-settings .provider-settings input,
+#provider-settings .provider-settings select,
+#provider-settings .provider-settings textarea {
+  width: 100%;
+  max-width: none;
 }
+
+/* API key eye button flush to the input */
+#provider-settings .provider-settings .api-key-wrap {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
 @media (max-width: 720px) {
   #provider-settings .provider-settings { grid-template-columns: 1fr; }
 }
 
-/* Context Settings section: divider line with title below; extra spacing */
-#context-settings { border-top: 1px solid var(--divider); padding-top: 14px; margin-top: 8px; }
-#context-settings > legend { display: block; margin: 6px 0 12px; padding: 0; }
+/* Slight extra spacing before the System Instructions textarea */
+#context-settings .form-row label[for="prompt-template"] {
+  display: inline-block;
+  margin-bottom: 6px;
+}
+
+/* Context Settings — clearer divider */
+#context-settings {
+  border-top: 2px solid var(--border-color);
+  padding-top: 16px;
+  margin-top: 10px;
+}
+
+/* References table styling */
+.references-table-wrapper {
+  overflow-x: auto;
+  max-width: 100%;
+  margin-top: 10px;
+}
+.references-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+.references-table th, .references-table td {
+  text-align: left;
+  padding: 8px;
+  border-bottom: 1px solid var(--border-color);
+  vertical-align: top;
+}
+.references-table thead th {
+  position: sticky;
+  top: 0;
+  background: var(--bg-main);
+  z-index: 1;
+}
+.references-table td:last-child {
+  word-break: break-all; /* long URLs */
+}
+
 #context-settings .form-row + .form-row { margin-top: 14px; }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -21,6 +21,9 @@
           <li><button class="icon-item" data-tab="bugs" aria-label="Bug / Feature Request"><img src="../icons/Bug.svg" alt="Bug icon"></button></li>
           <li><button class="icon-item" data-tab="privacy" aria-label="Privacy"><img src="../icons/privacyicon.svg" alt="Privacy icon"></button></li>
           <li><button class="icon-item" data-tab="help" aria-label="Help"><img src="../icons/Help.svg" alt="Help icon"></button></li>
+          <li><button class="icon-item" data-tab="references" aria-label="References">
+            <img src="../icons/ReferencesIcon.svg" alt="References icon">
+          </button></li>
         </ul>
         <!-- Bottom rail: theme toggle + branding -->
         <div class="rail-bottom">
@@ -69,6 +72,10 @@
         <li><button class="nav-item" data-tab="help">
           <span class="nav-title">Help</span>
           <span class="nav-subtitle">Support</span>
+        </button></li>
+        <li><button class="nav-item" data-tab="references">
+          <span class="nav-title">References</span>
+          <span class="nav-subtitle">API endpoints for popular LLMs</span>
         </button></li>
       </ul>
     </nav>
@@ -221,6 +228,23 @@
       <section id="help" class="tab-content" role="tabpanel">
         <h1 class="page-title">Help</h1>
         <p>Check the <a href="https://chrome.google.com/webstore/detail/chatgpt-answers-for-whats/bmbidjjfpkmlddlbkljbphdgpnjnpogk" target="_blank" rel="noopener">extension listing</a> for details and support.</p>
+      </section>
+      <section id="references" class="tab-content" role="tabpanel">
+        <h1 class="page-title">References</h1>
+        <p class="helper">API endpoints for popular LLMs.</p>
+        <div class="references-table-wrapper">
+          <table id="references-table" class="references-table">
+            <thead>
+              <tr>
+                <th>Provider</th>
+                <th>Model</th>
+                <th>Release Date</th>
+                <th>API Endpoint</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
       </section>
     </main>
   </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -89,6 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
   restoreOptions();
   reloadLogsAndSummary();
   setupNavigation();
+  loadReferences();
 });
 document.getElementById('options-form').addEventListener('submit', saveOptions);
 document.getElementById('download-csv').addEventListener('click', downloadCsv);
@@ -432,6 +433,48 @@ function renderLlmHistoryTable(logs) {
     row.appendChild(rt);
 
     tbody.appendChild(row);
+  });
+}
+
+async function loadReferences() {
+  try {
+    const res = await fetch('references.json');
+    if (!res.ok) return;
+    const data = await res.json();
+    renderReferencesTable(data);
+  } catch {}
+}
+
+function renderReferencesTable(rows) {
+  const tbody = document.querySelector('#references-table tbody');
+  if (!tbody) return;
+  tbody.innerHTML = '';
+
+  rows.forEach(r => {
+    const tr = document.createElement('tr');
+
+    const tdProv = document.createElement('td');
+    tdProv.textContent = r.provider || '';
+    tr.appendChild(tdProv);
+
+    const tdModel = document.createElement('td');
+    tdModel.textContent = r.model || '';
+    tr.appendChild(tdModel);
+
+    const tdDate = document.createElement('td');
+    tdDate.textContent = r.releaseDate || '';
+    tr.appendChild(tdDate);
+
+    const tdEp = document.createElement('td');
+    const a = document.createElement('a');
+    a.href = r.apiEndpoint || '';
+    a.textContent = r.apiEndpoint || '';
+    a.target = '_blank';
+    a.rel = 'noopener';
+    tdEp.appendChild(a);
+    tr.appendChild(tdEp);
+
+    tbody.appendChild(tr);
   });
 }
 

--- a/src/options/references.json
+++ b/src/options/references.json
@@ -1,0 +1,309 @@
+[
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5",
+    "releaseDate": "Aug 2025",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5-mini",
+    "releaseDate": "Aug 2025",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-5-nano",
+    "releaseDate": "Aug 2025",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-4.1",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-4.1-mini",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-4.1-nano",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-4o",
+    "releaseDate": "May 2024",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "gpt-4o-mini",
+    "releaseDate": "May 2024",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "o1",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "o1-preview",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "o1-mini",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "o1-pro",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "o3",
+    "releaseDate": "2025",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "o3-mini",
+    "releaseDate": "2025",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "o3-pro",
+    "releaseDate": "2025",
+    "apiEndpoint": "https://api.openai.com/v1/chat/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "text-embedding-3-large",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://api.openai.com/v1/embeddings"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "text-embedding-3-small",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://api.openai.com/v1/embeddings"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "dall-e-3",
+    "releaseDate": "2023",
+    "apiEndpoint": "https://api.openai.com/v1/images/generations"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "dall-e-2",
+    "releaseDate": "2022",
+    "apiEndpoint": "https://api.openai.com/v1/images/generations"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "whisper-1",
+    "releaseDate": "2022",
+    "apiEndpoint": "https://api.openai.com/v1/audio/transcriptions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "tts-1",
+    "releaseDate": "2023",
+    "apiEndpoint": "https://api.openai.com/v1/audio/speech"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "tts-1-hd",
+    "releaseDate": "2023",
+    "apiEndpoint": "https://api.openai.com/v1/audio/speech"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "babbage-002",
+    "releaseDate": "Legacy",
+    "apiEndpoint": "https://api.openai.com/v1/completions"
+  },
+  {
+    "provider": "OpenAI",
+    "model": "davinci-002",
+    "releaseDate": "Legacy",
+    "apiEndpoint": "https://api.openai.com/v1/completions"
+  },
+  {
+    "provider": "Anthropic",
+    "model": "Claude 4 – Sonnet 4",
+    "releaseDate": "May 2025",
+    "apiEndpoint": "https://api.anthropic.com/v1/messages"
+  },
+  {
+    "provider": "Anthropic",
+    "model": "Claude 4 – Opus 4",
+    "releaseDate": "May 2025",
+    "apiEndpoint": "https://api.anthropic.com/v1/messages"
+  },
+  {
+    "provider": "Anthropic",
+    "model": "Claude Opus 4.1",
+    "releaseDate": "Aug 2025",
+    "apiEndpoint": "https://api.anthropic.com/v1/messages"
+  },
+  {
+    "provider": "Anthropic",
+    "model": "Claude 3.7 – Sonnet",
+    "releaseDate": "Feb 2025",
+    "apiEndpoint": "https://api.anthropic.com/v1/messages"
+  },
+  {
+    "provider": "Anthropic",
+    "model": "Claude 3.5 – Sonnet",
+    "releaseDate": "Jun 2024",
+    "apiEndpoint": "https://api.anthropic.com/v1/messages"
+  },
+  {
+    "provider": "Anthropic",
+    "model": "Claude 3 – Haiku",
+    "releaseDate": "Mar 2024",
+    "apiEndpoint": "https://api.anthropic.com/v1/messages"
+  },
+  {
+    "provider": "Anthropic",
+    "model": "Claude 3 – Sonnet",
+    "releaseDate": "Mar 2024",
+    "apiEndpoint": "https://api.anthropic.com/v1/messages"
+  },
+  {
+    "provider": "Anthropic",
+    "model": "Claude 3 – Opus",
+    "releaseDate": "Mar 2024",
+    "apiEndpoint": "https://api.anthropic.com/v1/messages"
+  },
+  {
+    "provider": "Mistral",
+    "model": "Mistral 7B",
+    "releaseDate": "Sep 2023",
+    "apiEndpoint": "https://api.mistral.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Mistral",
+    "model": "Mixtral 8x7B",
+    "releaseDate": "Dec 2023",
+    "apiEndpoint": "https://api.mistral.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Mistral",
+    "model": "Codestral 22B",
+    "releaseDate": "May 2024",
+    "apiEndpoint": "https://api.mistral.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Mistral",
+    "model": "Mathstral 7B",
+    "releaseDate": "Jul 2024",
+    "apiEndpoint": "https://api.mistral.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Mistral",
+    "model": "Pixtral Large",
+    "releaseDate": "Nov 2024",
+    "apiEndpoint": "https://api.mistral.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Mistral",
+    "model": "Mistral Large 2",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://api.mistral.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Mistral",
+    "model": "Mistral Small 3.1",
+    "releaseDate": "Mar 2025",
+    "apiEndpoint": "https://api.mistral.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Mistral",
+    "model": "Mistral Medium 3",
+    "releaseDate": "May 2025",
+    "apiEndpoint": "https://api.mistral.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Mistral",
+    "model": "Magistral Small",
+    "releaseDate": "Jun 2025",
+    "apiEndpoint": "https://api.mistral.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Mistral",
+    "model": "Magistral Medium",
+    "releaseDate": "Jun 2025",
+    "apiEndpoint": "https://api.mistral.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Google DeepMind",
+    "model": "Gemini 1.5 Pro",
+    "releaseDate": "Feb 2024",
+    "apiEndpoint": "https://generativelanguage.googleapis.com/v1beta/models"
+  },
+  {
+    "provider": "Google DeepMind",
+    "model": "Gemini 1.5 Flash",
+    "releaseDate": "Feb 2024",
+    "apiEndpoint": "https://generativelanguage.googleapis.com/v1beta/models"
+  },
+  {
+    "provider": "Google DeepMind",
+    "model": "Gemini Ultra",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://generativelanguage.googleapis.com/v1beta/models"
+  },
+  {
+    "provider": "Meta AI",
+    "model": "Llama 3 8B",
+    "releaseDate": "Apr 2024",
+    "apiEndpoint": "https://api.meta.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Meta AI",
+    "model": "Llama 3 70B",
+    "releaseDate": "Apr 2024",
+    "apiEndpoint": "https://api.meta.ai/v1/chat/completions"
+  },
+  {
+    "provider": "Alibaba",
+    "model": "Qwen 2.5",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation"
+  },
+  {
+    "provider": "Alibaba",
+    "model": "Qwen 3",
+    "releaseDate": "2025",
+    "apiEndpoint": "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation"
+  },
+  {
+    "provider": "xAI",
+    "model": "Grok-1",
+    "releaseDate": "2024",
+    "apiEndpoint": "https://api.x.ai/v1/chat/completions"
+  },
+  {
+    "provider": "xAI",
+    "model": "Grok-3",
+    "releaseDate": "2025",
+    "apiEndpoint": "https://api.x.ai/v1/chat/completions"
+  }
+]
+


### PR DESCRIPTION
## Summary
- Align Provider Settings inputs in a two-column grid and style Provider/Context legends like page titles with a clearer divider.
- Add References tab and navigation, loading a scrollable table of LLM endpoints from `references.json`.
- Include table rendering logic and data fetch in options script.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68982e4f8d708320809b6ad36d4407bd