### PR TITLE
feat: support local llms without auth

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -129,6 +129,7 @@
               <label for="auth-scheme" id="auth-scheme-label">Auth Header</label>
               <div class="stack" id="auth-scheme-field">
                 <select id="auth-scheme">
+                  <option value="none">No Auth header</option>
                   <option value="bearer">Authorization: Bearer &lt;key&gt;</option>
                   <option value="x-api-key">X-API-Key: &lt;key&gt;</option>
                 </select>


### PR DESCRIPTION
## Summary
- allow custom OpenAI-compatible providers without an auth header
- hide API key UI and validation when "No Auth header" is selected
- improve background error handling and request host permissions per origin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68999e4efef48320ac0413253a575a8d