### PR TITLE
feat: sanitize custom endpoints and log latency metrics

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -3,6 +3,21 @@
   'use strict';
   const {extensionEnabled = true} = await chrome.storage.local.get({extensionEnabled: true});
   if (!extensionEnabled) return;
+  try {
+    const { apiChoice = 'openai', providerUrls = {} } =
+      await chrome.storage.local.get({ apiChoice: 'openai', providerUrls: {} });
+    if (apiChoice === 'custom') {
+      const base = (providerUrls.custom || '').trim();
+      const valid = base && /^https?:\/\//i.test(base) && /^\/v1\/?$/.test(new URL(base).pathname);
+      if (!valid) {
+        console.warn('Extension passive mode: Custom provider not configured or invalid base; skipping UI injection.');
+        return;
+      }
+    }
+  } catch (e) {
+    console.warn('Extension passive mode due to config parse error:', e);
+    return;
+  }
   if (window.__gptContentScriptLoaded) return;
   window.__gptContentScriptLoaded = true;
 

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -429,6 +429,8 @@ button {
 .history-table .col-ptok,
 .history-table .col-ctok,
 .history-table .col-ttok  { width: 7rem; text-align: right; }
+.history-table .col-ttft { width: 7rem; text-align: right; }
+.history-table .col-tps  { width: 7rem; text-align: right; }
 .history-table .col-rt    { width: 9rem; text-align: right; }
 
 @media (max-width: 1400px) {
@@ -436,7 +438,9 @@ button {
   .history-table .col-output { width: 20rem; }
   .history-table .col-ptok,
   .history-table .col-ctok,
-  .history-table .col-ttok { width: 6rem; }
+  .history-table .col-ttok,
+  .history-table .col-ttft,
+  .history-table .col-tps { width: 6rem; }
   .history-table .col-rt { width: 8rem; }
 }
 @media (max-width: 1200px) {
@@ -448,10 +452,14 @@ button {
 .history-table th:nth-child(6),
 .history-table th:nth-child(7),
 .history-table th:nth-child(8),
+.history-table th:nth-child(9),
+.history-table th:nth-child(10),
 .history-table td:nth-child(5),
 .history-table td:nth-child(6),
 .history-table td:nth-child(7),
-.history-table td:nth-child(8) {
+.history-table td:nth-child(8),
+.history-table td:nth-child(9),
+.history-table td:nth-child(10) {
   text-align: right;
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -121,8 +121,8 @@
               <!-- API Endpoint (read-only for built-ins, editable for Custom) -->
               <label for="api-endpoint">API Endpoint</label>
               <div class="stack">
-                <input id="api-endpoint" class="api-key-input monospace" type="text" placeholder="https://host.example.com/v1">
-                <div class="helper">Base URL of your provider (OpenAI‑compatible). For example: <code>https://localhost:11434/v1</code>.</div>
+                <input id="api-endpoint" class="api-key-input monospace" type="text" placeholder="http://localhost:1234/v1">
+                <div class="helper">Base URL of your provider (OpenAI‑compatible). Paste anything, we'll auto‑correct to <code>.../v1</code>. Do NOT include <code>/chat/completions</code>.</div>
               </div>
 
               <!-- Auth Header (show only for Custom; we’ll toggle via JS) -->
@@ -178,6 +178,8 @@
                 <col class="col-ptok">
                 <col class="col-ctok">
                 <col class="col-ttok">
+                <col class="col-ttft">
+                <col class="col-tps">
                 <col class="col-rt">
               </colgroup>
               <thead>
@@ -189,6 +191,8 @@
                   <th>Prompt Tokens</th>
                   <th>Completion Tokens</th>
                   <th>Total Tokens</th>
+                  <th>TTFT (ms)</th>
+                  <th>Tok/s</th>
                   <th>Response Time (ms)</th>
                 </tr>
               </thead>


### PR DESCRIPTION
## Summary
- Auto-normalize custom API endpoints to `/v1` and validate before save
- Skip WhatsApp injection when custom base URL is missing or invalid
- Track TTFT and tokens/sec for responses and expose in UI & CSV export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899c7b8d3b083208fead7580cccca20