### PR TITLE
Fix loader centering, per-chat routing, theme-bound icons

### DIFF
--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -11,12 +11,15 @@ function createGptButton(label = 'Suggest Response', id) {
     gptButton,
     setBusy(value) {
       if (value) {
-        const width = gptButton.getBoundingClientRect().width;
-        gptButton.style.width = `${width}px`;
+        const rect = gptButton.getBoundingClientRect();
+        // Lock current footprint so the spinner centers correctly
+        gptButton.style.minWidth = Math.ceil(rect.width) + 'px';
+        gptButton.style.minHeight = Math.ceil(rect.height) + 'px';
         gptButton.classList.add('loading');
       } else {
         gptButton.classList.remove('loading');
-        gptButton.style.width = '';
+        gptButton.style.minWidth = '';
+        gptButton.style.minHeight = '';
       }
     }
   };


### PR DESCRIPTION
## Summary
- Ensure GPT buttons lock width and height while loading to keep the spinner perfectly centered
- Route LLM responses to the correct chat via requestId, avoiding cross-chat bleed
- Respect the extension's Light/Dark preference for button icons and spinners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899e628cfb88320af5b484f879f2363