### PR TITLE
feat: theme-aware icons and streaming delete

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -225,6 +225,17 @@ body.dark { --icon-filter: invert(1) brightness(1.2); }
   --message-spinner-border: rgba(0,0,0,.1);
   --message-spinner-top: #54656F;
 }
+
+/* Icon color tokens for our inline SVG buttons */
+:root { --gpt-icon-color: #54656F; }            /* WA light tone */
+body.dark { --gpt-icon-color: #d1d7db; }        /* WA dark tone */
+/* Fallback for OS dark when WA hasn't set body.dark */
+@media (prefers-color-scheme: dark) {
+  body:not(.dark) { --gpt-icon-color: #d1d7db; }
+}
+/* Extension theme override (Options -> themePreference) */
+[data-gpt-theme="dark"]  { --gpt-icon-color: #d1d7db; }
+[data-gpt-theme="light"] { --gpt-icon-color: #54656F; }
 `;
 document.head.appendChild(style);
 
@@ -722,6 +733,7 @@ async function writeTextToSuggestionField(response, isLoading = false) {
       if (entry) {
         entry.streamingText += request.data;
         if (entry.paragraphEl) entry.paragraphEl.textContent = entry.streamingText;
+        updateDeleteButtonVisibility();
       }
     } else if (request.type === 'done') {
       if (entry?.buttonObject) entry.buttonObject.setBusy(false);
@@ -740,6 +752,7 @@ async function writeTextToSuggestionField(response, isLoading = false) {
       if (entry?.buttonObject) entry.buttonObject.setBusy(false);
       if (entry?.paragraphEl && request.response?.text) {
         entry.paragraphEl.textContent = request.response.text.replace(/^Me:\s*/, '');
+        updateDeleteButtonVisibility();
       }
       pendingRequests.delete(id);
     }

--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -26,22 +26,25 @@ function createGptButton(label = 'Suggest Response', id) {
 }
 
 function createButtonEmpty(title) {
-    const buttonElement = document.createElement("button");
-    buttonElement.innerHTML = "<button class=\"svlsagor\"><span><svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" preserveAspectRatio=\"xMidYMid meet\"></svg></span></button>";
-    buttonElement.setAttribute('title', title);
-    const svg = buttonElement.querySelector('svg');
-    const inner = buttonElement.querySelector('button');
-    if (inner) {
-      inner.style.display = 'flex';
-      inner.style.alignItems = 'center';
-      inner.style.justifyContent = 'center';
-      inner.style.width = '24px';
-      inner.style.height = '24px';
-      inner.style.padding = '0';
-      inner.style.border = 'none';
-      inner.style.background = 'transparent';
-    }
-    return {svg, buttonElement};
+  const buttonElement = document.createElement('button');
+  buttonElement.innerHTML = '<button class="svlsagor"><span><svg viewBox="0 0 24 24" width="20" height="20" preserveAspectRatio="xMidYMid meet"></svg></span></button>';
+  buttonElement.setAttribute('title', title);
+  // Make inline SVG honor theme color
+  buttonElement.style.color = 'var(--gpt-icon-color)';
+  const svg = buttonElement.querySelector('svg');
+  const inner = buttonElement.querySelector('button');
+  if (inner) {
+    inner.style.display = 'flex';
+    inner.style.alignItems = 'center';
+    inner.style.justifyContent = 'center';
+    inner.style.width = '24px';
+    inner.style.height = '24px';
+    inner.style.padding = '0';
+    inner.style.border = 'none';
+    inner.style.background = 'transparent';
+    inner.style.color = 'var(--gpt-icon-color)';
+  }
+  return {svg, buttonElement};
 }
 
 function createAndAddOptionsButton(newButtonContainer) {
@@ -84,9 +87,6 @@ function createAndAddOptionsButton(newButtonContainer) {
         svgElement.appendChild(cloned);
       });
     });
-  const innerBtn = optionsButton.querySelector('button');
-  optionsButton.style.filter = 'var(--icon-filter)';
-  if (innerBtn) innerBtn.style.filter = 'var(--icon-filter)';
   optionsButton.addEventListener('click', () => {
     chrome.runtime.sendMessage({action: 'openOptionsPage'}, response => {
       if (chrome.runtime.lastError || !response) {
@@ -115,9 +115,6 @@ function creatCopyButton(newFooter, newButtonContainer) {
         svgElement.appendChild(path);
       });
     });
-  const innerBtn = copyButton.querySelector('button');
-  copyButton.style.filter = 'var(--icon-filter)';
-  if (innerBtn) innerBtn.style.filter = 'var(--icon-filter)';
   newButtonContainer.appendChild(copyButton);
   return copyButton;
 }
@@ -140,9 +137,6 @@ function createDeleteButton(newFooter, newButtonContainer) {
         svgElement.appendChild(path);
       });
     });
-  const innerBtn = deleteButton.querySelector('button');
-  deleteButton.style.filter = 'var(--icon-filter)';
-  if (innerBtn) innerBtn.style.filter = 'var(--icon-filter)';
   deleteButton.style.display = 'none';
   newButtonContainer.appendChild(deleteButton);
   return deleteButton;


### PR DESCRIPTION
## Summary
- ensure inline SVG icons honor extension theme via `--gpt-icon-color`
- show delete icon while tokens stream and after final reply

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899f660c4d88320821fdb299b77c993