### PR TITLE
feat: add first-run configuration flow

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -29,6 +29,13 @@ function sanitizeBaseEndpoint(raw) {
 
 const CONTENT_SCRIPTS = ['parser.js', 'uiStuff.js', 'improveDialog.js', 'contentScript.js'];
 
+chrome.runtime.onInstalled.addListener(({ reason }) => {
+  if (reason === 'install') {
+    chrome.storage.local.set({ onboardingDone: false, firstRunAt: Date.now() });
+    chrome.runtime.openOptionsPage();
+  }
+});
+
 let decryptedApiKeys = {};
 let extensionEnabled = true;
 
@@ -308,9 +315,10 @@ function statusToUserMessage(status) {
 async function initExtension() {
   await loadExtensionEnabled();
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if (request.action === 'openOptionsPage') {
+    if (request && request.action === 'openOptionsPage') {
       chrome.runtime.openOptionsPage();
-      sendResponse({received: true});
+      sendResponse({ ok: true });
+      return true;
     } else if (request.message === 'sendChatToGpt') {
       sendLLM(request.prompt, sender.tab.id, request.inputChatData, request.requestId);
       sendResponse({received: true});

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -891,3 +891,16 @@ label {
   overflow-wrap: anywhere;
   word-break: break-word;
 }
+
+.card.quickstart {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin: 8px 0 16px;
+}
+.card.quickstart h2 {
+  margin: 0 0 8px;
+  font-size: 18px;
+}
+.card.quickstart .monospace { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -82,6 +82,17 @@
     <main id="main-content" class="main-content">
       <section id="settings" class="tab-content active" role="tabpanel">
         <h1 class="page-title">Settings</h1>
+        <div id="quick-start" class="card quickstart" hidden>
+          <h2>Quick Start</h2>
+          <ol>
+            <li>Choose a provider.</li>
+            <li>Paste API key (if required).</li>
+            <li>Click <strong>Save</strong>.</li>
+            <li><button type="button" id="open-wa-web" class="primary-button">Open WhatsApp Web</button></li>
+          </ol>
+          <div class="helper">Not sure your setup works? Try <button type="button" id="test-models" class="primary-button">Test models</button></div>
+          <div id="models-result" class="helper monospace" aria-live="polite"></div>
+        </div>
         <form id="options-form">
           <fieldset id="provider-settings">
             <legend>Provider Settings</legend>
@@ -119,10 +130,12 @@
               </div>
 
               <!-- API Endpoint (read-only for built-ins, editable for Custom) -->
-              <label for="api-endpoint">API Endpoint</label>
-              <div class="stack">
-                <input id="api-endpoint" class="api-key-input monospace" type="text" placeholder="http://localhost:1234/v1">
-                <div class="helper">Base URL of your provider (OpenAI‑compatible). Paste anything, we'll auto‑correct to <code>.../v1</code>. Do NOT include <code>/chat/completions</code>.</div>
+              <div id="endpoint-row">
+                <label for="api-endpoint">API Endpoint</label>
+                <div class="stack">
+                  <input id="api-endpoint" class="api-key-input monospace" type="text" placeholder="http://localhost:1234/v1">
+                  <div class="helper">Base URL (must end with <code>/v1</code>). Do NOT include <code>/chat/completions</code>.</div>
+                </div>
               </div>
 
               <!-- Auth Header (show only for Custom; we’ll toggle via JS) -->

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const settingsBtn = document.getElementById('open-settings');
   const toggleBtn = document.getElementById('toggle-extension');
   const bugBtn = document.getElementById('submit-bug');
@@ -12,6 +12,14 @@ document.addEventListener('DOMContentLoaded', () => {
     chrome.tabs.create({url: 'https://github.com/PalWorks/AI-Suggested-Replies-For-WhatsApp/issues'});
     window.close();
   });
+
+  try {
+    const { getConfigState } = await import(chrome.runtime.getURL('utils.js'));
+    const state = await getConfigState();
+    settingsBtn.textContent = state.isConfigured ? 'Open Settings' : 'Get Started';
+  } catch {
+    // keep default label
+  }
 
   chrome.storage.local.get({extensionEnabled: true}, ({extensionEnabled}) => {
     toggleBtn.textContent = extensionEnabled ? 'Turn Off' : 'Turn On';


### PR DESCRIPTION
## Summary
- open options on first install and allow runtime requests to open options
- add config state helper, Quick Start guide, and custom-only endpoint/auth fields
- show first-run hints and dynamic labels when extension isn't configured

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b0d7381f883208d37f1861532242a