### PR TITLE
feat: refine options UI and add setup nudge

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -14,42 +14,26 @@
     document.documentElement.removeAttribute('data-gpt-theme');
   }
   if (!extensionEnabled) return;
-  function insertFirstRunHint() {
-    const host = document.querySelector('[contenteditable="true"]')?.closest('footer') || document.body;
-    if (!host || host.__gptFirstRunHint) return;
-    const pill = document.createElement('button');
-    pill.textContent = 'Set up AI Suggestions';
-    pill.type = 'button';
-    pill.style.cssText = 'position:fixed; right:12px; bottom:12px; z-index:9999; padding:8px 12px; border-radius:999px; border:1px solid #b3e2cd; background:#e7f6ee; color:#075e54; cursor:pointer;';
-    pill.addEventListener('click', () => chrome.runtime.sendMessage({ action: 'openOptionsPage' }));
-    document.body.appendChild(pill);
-    host.__gptFirstRunHint = pill;
-  }
 
+  // Determine whether the extension is fully configured.
+  let _configured = true;
   try {
-    const { apiChoice = 'openai', providerUrls = {}, apiKeys = {}, authSchemes = {} } =
-      await chrome.storage.local.get({ apiChoice: 'openai', providerUrls: {}, apiKeys: {}, authSchemes: {} });
+    const { apiChoice = 'openai', apiKeys = {}, encKey = '', providerUrls = {}, authSchemes = {} } =
+      await chrome.storage.local.get({ apiChoice: 'openai', apiKeys: {}, encKey: '', providerUrls: {}, authSchemes: {} });
 
-    let notConfigured = false;
+    const hasKey = !!(apiKeys?.[apiChoice]?.encryptedKey && encKey);
     if (apiChoice === 'custom') {
       const base = (providerUrls.custom || '').trim();
       let valid = false;
-      try { const u = new URL(base); valid = u.pathname === '/v1'; } catch {}
-      const needsKey = (authSchemes.custom || 'none') !== 'none';
-      const hasKey = !!apiKeys.custom;
-      notConfigured = !(valid && (!needsKey || hasKey));
+      try { valid = base && /^https?:\/\//i.test(base) && /^\/v1\/?$/.test(new URL(base).pathname); } catch {}
+      const scheme = (authSchemes.custom || 'none');
+      _configured = valid && (scheme === 'none' || hasKey);
     } else {
-      const needsKey = true;
-      const hasKey = !!apiKeys[apiChoice];
-      notConfigured = !hasKey;
-    }
-    if (notConfigured) {
-      insertFirstRunHint();
-      return;
+      _configured = hasKey; // built-ins require a key
     }
   } catch (e) {
-    insertFirstRunHint();
-    return;
+    console.warn('Configuration check error:', e);
+    _configured = false;
   }
   if (window.__gptContentScriptLoaded) return;
   window.__gptContentScriptLoaded = true;
@@ -159,6 +143,17 @@ style.textContent = `
   background: #e7f6ee !important;
   color: #075e54 !important;
   border-color: #b3e2cd !important;
+}
+/* Emphasized nudge button */
+.wa-reply-btn.nudge-setup {
+  background: #25D366 !important;
+  color: #fff !important;
+  border-color: #1ebe5d !important;
+}
+.wa-reply-btn.nudge-setup:hover,
+.wa-reply-btn.nudge-setup:focus {
+  background: #1ebe5d !important;
+  color: #fff !important;
 }
 
 .gpt-message {
@@ -533,6 +528,10 @@ function getDraftText() {
 function updateImproveButtonState() {
   const button = globalImproveButtonObject && globalImproveButtonObject.gptButton;
   if (!button) return;
+  if (!_configured) {
+    button.disabled = true;
+    return;
+  }
   const hasText = getDraftText().length > 0;
   button.disabled = !hasText;
 }
@@ -634,7 +633,9 @@ function injectUI(mainNode) {
         gptButtonObject,
         improveButtonObject,
         copyButton,
-        deleteButton
+        deleteButton,
+        buttonContainer,
+        buttonContainer2
       } = createGptFooter(footer, mainNode);
     globalGptButtonObject = gptButtonObject;
     globalImproveButtonObject = improveButtonObject;
@@ -662,6 +663,20 @@ function injectUI(mainNode) {
   });
   const improveButton = improveButtonObject.gptButton;
   improveButton.addEventListener('click', improveButtonClicked);
+
+  // If not configured, disable main actions and add a "Set up AI Suggestions" nudge
+  if (!_configured) {
+    gptButton.disabled = true;
+    improveButton.disabled = true;
+    const setupBtn = document.createElement('button');
+    setupBtn.type = 'button';
+    setupBtn.className = 'gptbtn wa-reply-btn nudge-setup';
+    setupBtn.textContent = 'Set up AI Suggestions';
+    (buttonContainer2 || buttonContainer).appendChild(setupBtn);
+    setupBtn.addEventListener('click', () => {
+      chrome.runtime.sendMessage({ action: 'openOptionsPage' }, () => {});
+    });
+  }
 
   // Watch input changes to toggle the "Improve my response" button
   const textarea = mainNode.querySelector('[contenteditable="true"]');

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -904,3 +904,55 @@ label {
   font-size: 18px;
 }
 .card.quickstart .monospace { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+
+/* --- API Key row with right-side Test button --- */
+.provider-settings .api-line {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+/* Keep eye icon inside the field */
+#provider-settings .provider-settings .api-key-wrap {
+  position: relative;
+  display: block;
+}
+#provider-settings .provider-settings .api-key-wrap input {
+  padding-right: 42px;
+}
+#provider-settings .provider-settings .api-key-wrap .eye-icon {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  padding: 0;
+}
+
+/* Button variants */
+.secondary-button {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.actions-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+.primary-button.ghost {
+  background: #25D366;
+  border-color: #1ebe5d;
+}
+.primary-button.ghost[hidden] { display: none; }
+
+/* Subtle "pulse" on first reveal after Save */
+@keyframes pulseOnce {
+  0% { box-shadow: 0 0 0 0 rgba(37,211,102,.5); }
+  100% { box-shadow: 0 0 0 14px rgba(37,211,102,0); }
+}
+.primary-button.ghost.pulse {
+  animation: pulseOnce 650ms ease-out 1;
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -88,10 +88,7 @@
             <li>Choose a provider.</li>
             <li>Paste API key (if required).</li>
             <li>Click <strong>Save</strong>.</li>
-            <li><button type="button" id="open-wa-web" class="primary-button">Open WhatsApp Web</button></li>
           </ol>
-          <div class="helper">Not sure your setup works? Try <button type="button" id="test-models" class="primary-button">Test models</button></div>
-          <div id="models-result" class="helper monospace" aria-live="polite"></div>
         </div>
         <form id="options-form">
           <fieldset id="provider-settings">
@@ -113,18 +110,24 @@
               <!-- Model Name -->
               <label for="model-name">Model Name</label>
               <div class="stack">
-                <input type="text" id="model-name" name="model-name" class="wide-input" placeholder="gpt-3.5-turbo">
+                <input type="text" id="model-name" name="model-name" class="wide-input" placeholder="gpt-4o-mini">
                 <p class="helper">Enter the model name exactly as supported by your provider. Leave blank for default.</p>
               </div>
 
               <!-- API Key -->
               <label for="api-key">API Key</label>
               <div class="stack">
-                <div class="api-key-wrap">
-                  <input type="password" id="api-key" name="api-key" class="wide-input monospace api-key-input" aria-describedby="api-key-feedback">
-                  <button type="button" id="toggle-api-key" aria-label="Show API key" class="eye-icon">
-                    <img src="../icons/Eye Icon - Show Password.svg" alt="">
-                  </button>
+                <div class="api-line">
+                  <div class="api-key-wrap">
+                    <input type="password" id="api-key" name="api-key"
+                           class="wide-input monospace api-key-input"
+                           aria-describedby="api-key-feedback">
+                    <button type="button" id="toggle-api-key"
+                            aria-label="Show API key" class="eye-icon">
+                      <img src="../icons/Eye Icon - Show Password.svg" alt="">
+                    </button>
+                  </div>
+                  <button type="button" id="test-models" class="secondary-button">Test models</button>
                 </div>
                 <div id="api-key-feedback" class="feedback" role="status" aria-live="polite"></div>
               </div>
@@ -171,7 +174,10 @@
               </label>
             </div>
 
-            <button type="submit" id="save-button" class="primary-button">Save</button>
+            <div class="actions-row">
+              <button type="submit" id="save-button" class="primary-button">Save</button>
+              <button type="button" id="open-wa-web" class="primary-button ghost" hidden>Open WhatsApp Web</button>
+            </div>
           </form>
         </section>
       <section id="history" class="tab-content" role="tabpanel">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -133,16 +133,11 @@ const showIcon = '../icons/Eye Icon - Show Password.svg';
 const hideIcon = '../icons/Eye Icon - Hide Password.svg';
 const feedbackBox = document.getElementById('api-key-feedback');
 const saveBtn = document.getElementById('save-button');
+const openWaBtn = document.getElementById('open-wa-web');
+const testModelsBtn = document.getElementById('test-models');
 const contextLimitInput = document.getElementById('context-message-limit');
 const endpointInput = document.getElementById('api-endpoint');
 const authSchemeSelect = document.getElementById('auth-scheme');
-
-const openWaBtn = document.getElementById('open-wa-web');
-if (openWaBtn) {
-  openWaBtn.addEventListener('click', () => {
-    chrome.tabs.create({ url: 'https://web.whatsapp.com' });
-  });
-}
 
 endpointInput.addEventListener('blur', () => {
   const n = sanitizeBaseEndpoint(endpointInput.value);
@@ -180,6 +175,16 @@ authSchemeSelect.addEventListener('change', () => {
   validateTimeout = setTimeout(validateApiKey, 300);
 });
 
+if (testModelsBtn) {
+  testModelsBtn.addEventListener('click', () => {
+    clearTimeout(validateTimeout);
+    validateApiKey(true); // true => show model list
+  });
+}
+if (openWaBtn) {
+  openWaBtn.addEventListener('click', openWhatsAppWeb);
+}
+
 function showAuthRow(show) {
   const label = document.getElementById('auth-scheme-label') || document.querySelector('label[for="auth-scheme"]');
   const field = document.getElementById('auth-scheme-field') || document.getElementById('auth-scheme')?.closest('.stack') || document.getElementById('auth-scheme')?.parentElement;
@@ -199,42 +204,6 @@ async function reflectQuickStart() {
   if (qs) qs.hidden = !!state.isConfigured;
 }
 document.addEventListener('DOMContentLoaded', reflectQuickStart);
-
-async function testModels() {
-  const provider = apiChoiceSelect.value;
-  const scheme = (provider === 'custom' ? (authSchemeSelect.value || 'none') : defaultAuth(provider));
-  let base = provider === 'custom'
-    ? sanitizeBaseEndpoint(endpointInput.value.trim() || providerUrls.custom || '')
-    : defaultBase(provider);
-  if (provider === 'custom') endpointInput.value = base;
-
-  const url = `${base}/models`;
-  const headers = {};
-  const apiKey = apiKeyInput.value.trim();
-  if (scheme === 'bearer' && apiKey) headers.Authorization = `Bearer ${apiKey}`;
-  if (scheme === 'x-api-key' && apiKey) headers['x-api-key'] = apiKey;
-  if (provider === 'openrouter') {
-    headers['HTTP-Referer'] = 'https://web.whatsapp.com';
-    headers['X-Title'] = 'AI Suggested Replies For WhatsApp';
-  }
-
-  const out = document.getElementById('models-result');
-  out.textContent = 'Testing…';
-  try {
-    const res = await fetch(url, { headers });
-    const data = await res.json();
-    const list = (Array.isArray(data?.data) ? data.data : (Array.isArray(data?.models) ? data.models : []));
-    const ids = list
-      .map(m => (typeof m === 'string' ? m : (m.id || m.name || m.slug)))
-      .filter(Boolean)
-      .slice(0, 5);
-    out.textContent = ids.length ? `Models: ${ids.join(', ')}` : 'No models found.';
-  } catch (e) {
-    out.textContent = 'Error fetching models.';
-  }
-}
-const testBtn = document.getElementById('test-models');
-if (testBtn) testBtn.addEventListener('click', testModels);
 
 function toggleApiKeyRow() {
   const keyLabel = document.querySelector('label[for="api-key"]');
@@ -267,6 +236,32 @@ function setFeedback(message, type) {
   }
 }
 
+function parseModelIds(payload) {
+  try {
+    const out = new Set();
+    const data = payload?.data || payload?.models || payload;
+    if (Array.isArray(data)) {
+      for (const m of data) {
+        if (typeof m === 'string') out.add(m);
+        else if (m?.id) out.add(String(m.id));
+        else if (m?.name) out.add(String(m.name));
+      }
+    }
+    return Array.from(out).sort((a,b) => a.localeCompare(b)).slice(0, 40);
+  } catch { return []; }
+}
+
+async function openWhatsAppWeb() {
+  chrome.tabs.query({ url: 'https://web.whatsapp.com/*' }, (tabs) => {
+    if (tabs && tabs.length) {
+      for (const t of tabs) { chrome.tabs.reload(t.id); }
+      chrome.tabs.update(tabs[0].id, { active: true });
+    } else {
+      chrome.tabs.create({ url: 'https://web.whatsapp.com/' });
+    }
+  });
+}
+
 async function getOrCreateEncKey() {
   const {encKey} = await chrome.storage.local.get({encKey: ''});
   if (encKey) {
@@ -278,7 +273,7 @@ async function getOrCreateEncKey() {
   return key;
 }
 
-async function validateApiKey() {
+async function validateApiKey(showModels = false) {
   const apiKey = apiKeyInput.value.trim();
   const provider = apiChoiceSelect.value;
   const scheme = (provider === 'custom' ? (authSchemeSelect.value || 'none') : defaultAuth(provider));
@@ -303,11 +298,25 @@ async function validateApiKey() {
 
   try {
     const res = await fetch(url, { headers });
-    if (scheme === 'none') {
-      setFeedback(res.ok ? 'Endpoint reachable' : `Endpoint error (${res.status})`, res.ok ? 'success' : 'error');
-    } else {
-      setFeedback(res.ok ? 'Key verified' : 'Invalid key', res.ok ? 'success' : 'error');
+    const ok = res.ok;
+    let msg = '';
+    let type = ok ? 'success' : 'error';
+    let modelList = [];
+    if (ok) {
+      const payload = await res.json().catch(() => null);
+      modelList = parseModelIds(payload);
     }
+    if (scheme === 'none') {
+      msg = ok ? 'Endpoint reachable' : `Endpoint error (${res.status})`;
+    } else {
+      msg = ok ? 'Key verified' : 'Invalid key';
+    }
+    if (ok && showModels && modelList.length) {
+      msg += `. Available models: ${modelList.join(', ')}`;
+      // hint the placeholder to first popular one
+      modelInput.placeholder = modelList[0] || getDefaultModel(provider);
+    }
+    setFeedback(msg, type);
   } catch (e) {
     setFeedback('Connection error (is the server running?)', 'error');
   }
@@ -363,15 +372,16 @@ async function saveOptions(e) {
   };
 
   chrome.storage.local.set(storeObj, async () => {
-    if (showAdvancedImprove && !prev.showAdvancedImprove) {
-      refreshWhatsAppTabs();
+    // After saving, nudge user to (re)open WA Web
+    if (openWaBtn) {
+      openWaBtn.hidden = false;
+      openWaBtn.classList.remove('pulse');
+      void openWaBtn.offsetWidth;
+      openWaBtn.classList.add('pulse');
     }
     const original = saveBtn.textContent;
-    saveBtn.textContent = 'Saved!';
-    try {
-      showToast('Saved. Open WhatsApp Web to try it.', { anchor: saveBtn, align: 'right', duration: 2200 });
-    } catch {}
-    setTimeout(() => { saveBtn.textContent = original; }, 1800);
+    saveBtn.textContent = 'Saved';
+    setTimeout(() => { saveBtn.textContent = original; }, 1200);
     try {
       const { getConfigState } = await import(chrome.runtime.getURL('utils.js'));
       const state = await getConfigState();
@@ -385,6 +395,9 @@ async function saveOptions(e) {
   if (provider === 'custom' && providerUrls.custom) {
     chrome.runtime.sendMessage({ message: 'providerChanged', providerUrl: providerUrls.custom }, () => {});
   }
+
+  // Optionally refresh currently open WA tabs so the new config takes effect immediately
+  refreshWhatsAppTabs();
 }
 
 async function loadProviderFields(provider) {

--- a/src/uiStuff.js
+++ b/src/uiStuff.js
@@ -230,7 +230,9 @@ function createGptFooter(footer, mainNode) {
         gptButtonObject,
         improveButtonObject,
         copyButton,
-        deleteButton
+        deleteButton,
+        buttonContainer,
+        buttonContainer2
     };
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,7 +90,8 @@ export function getDefaultModel(provider) {
   switch (provider) {
     case 'openrouter':
     case 'openai':
-      return 'gpt-3.5-turbo';
+      // Use the faster/cheaper multimodal default by default
+      return 'gpt-4o-mini';
     case 'anthropic':
       return 'claude-3-haiku-20240307';
     case 'mistral':


### PR DESCRIPTION
## Summary
- default to `gpt-4o-mini` for OpenAI and OpenRouter
- add model testing and open WhatsApp Web actions in options
- show setup nudge and disable buttons when extension not configured

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b1f7328ac8320a5ca5739779e475e